### PR TITLE
namespace-fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Python
+__pycache__/
+*.pyc
+
+# ROS
+build/
+devel/
+logs/
+install/
+build_isolated/
+devel_isolated/
+*.bag
+CATKIN_IGNORE
+
+# Misc
+.vscode/
+*.swp
+log/
+test/

--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ roslaunch bcr_bot rviz.launch
 
 The launch file accepts multiple launch arguments,
 ```bash
-roslaunch bcr_bot gazebo.launch 
-	camera_enabled:=True
-	two_d_lidar_enabled:=True
-	position_x:=0.0
-	position_y:=0.0
-	orientation_yaw:=0.0
+roslaunch bcr_bot gazebo.launch \
+	camera_enabled:=True \
+	two_d_lidar_enabled:=True \
+	position_x:=0.0 \
+	position_y:=0.0 \
+	orientation_yaw:=0.0 \
+	odometry_source:=world \
 	world_file:=small_warehouse.world
 ```
 
@@ -86,13 +87,14 @@ ros2 launch bcr_bot rviz.launch.py
 
 The launch file accepts multiple launch arguments,
 ```bash
-ros2 launch bcr_bot gazebo.launch.py 
-	camera_enabled:=True
-	two_d_lidar_enabled:=True
-	position_x:=0.0
-	position_y:=0.0
-	orientation_yaw:=0.0
-	world_file:=small_warehouse.world
+ros2 launch bcr_bot gazebo.launch.py \
+	camera_enabled:=True \
+	two_d_lidar_enabled:=True \
+	position_x:=0.0 \
+	position_y:=0.0 \
+	orientation_yaw:=0.0 \
+	odometry_source:=world \
+	world_file:=small_warehouse.sdf
 ```
 
 ## Humble + Fortress (Ubuntu 22.04)
@@ -132,13 +134,13 @@ ros2 launch bcr_bot rviz.launch.py
 
 The launch file accepts multiple launch arguments,
 ```bash
-ros2 launch bcr_bot gz.launch.py 
-	camera_enabled:=True
-	two_d_lidar_enabled:=True
-	position_x:=0.0
-	position_y:=0.0
-	orientation_yaw:=0.0
-	world_file:=small_warehouse.world
+ros2 launch bcr_bot gz.launch.py \
+	camera_enabled:=True \
+	two_d_lidar_enabled:=True \
+	position_x:=0.0 \
+	position_y:=0.0 \
+	orientation_yaw:=0.0 \
+	world_file:=small_warehouse.sdf
 ```
 
 ### Simulation and Visualization

--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -18,6 +18,7 @@
 <arg name="position_x"              default="0.0"/>
 <arg name="position_y"              default="0.0"/>
 <arg name="orientation_yaw"         default="0.0"/>
+<arg name="odometry_source"         default="world"/>
 
 <!-- ............................... LAUNCH WORLD ................................... -->
 
@@ -40,6 +41,7 @@
 	conveyor_enabled:=$(arg conveyor_enabled)
 	ground_truth_frame:=$(arg ground_truth_frame)
 	robot_namespace:=$(arg robot_namespace)
+	odometry_source:=$(arg odometry_source)
 	" />
 
 <!-- ................................ SPAWN MODEL .................................... -->
@@ -48,7 +50,7 @@
 <node name="spawn_model" pkg="gazebo_ros" type="spawn_model"
 	args="-param robot_description
 		-urdf
-		-model bcr_bot
+		-model $(arg robot_namespace)
 		-x $(arg position_x)
         -y $(arg position_y)
 		-z 0.9

--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -28,7 +28,7 @@
 <xacro:property name="two_d_lidar_sample_size"     value="361"/>
 <xacro:property name="two_d_lidar_min_angle"       value="0"/>
 <xacro:property name="two_d_lidar_max_angle"       value="360"/>
-<xacro:property name="two_d_lidar_min_range"       value="0.1"/>
+<xacro:property name="two_d_lidar_min_range"       value="0.55"/>
 <xacro:property name="two_d_lidar_max_range"       value="16"/>
 
 <xacro:property name="camera_baseline"             value="0.06"/>
@@ -42,6 +42,7 @@
 <xacro:arg      name="publish_wheel_odom_tf"       default="true"/>
 <xacro:arg      name="conveyor_enabled"            default="false"/>
 <xacro:arg      name="ground_truth_frame"          default="map"/>
+<xacro:arg      name="odometry_source"             default="world"/>
 
 
 <!-- ............................... LOAD MACROS ................................. -->
@@ -124,7 +125,7 @@
    <joint name="two_d_lidar_joint" type="fixed">
       <parent link="base_link"/>
       <child link="two_d_lidar"/>
-      <origin xyz="0.3 0 0.08" rpy="0 0 0" />
+      <origin xyz="0 0 0.08" rpy="0 0 0" />
     </joint>
 
    <gazebo reference="two_d_lidar">

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -27,7 +27,7 @@
 		<publishWheelTF>false</publishWheelTF>
 		<publishWheelJointState>true</publishWheelJointState>
 		<publishOdometryMsg>true</publishOdometryMsg>
-		<odometrySource>encoder</odometrySource>
+		<odometrySource>$(arg odometry_source)</odometrySource>
 		<wheelAcceleration>5.0</wheelAcceleration>
 	</plugin>
 </gazebo>


### PR DESCRIPTION
Pull Request: Update 'model' argument and add xacro argument for odometry_source

### Description
1. The first change modifies the 'model' argument of the spawn model node to use the `$(arg robot_namespace)` value. 
2. The second change adds a new xacro argument called 'odometry_source' to the `bcr_bot.xacro` file. This argument is utilized for the `<odometry_source>` tag within the differential drive plugin and can also be modified using a launch argument.
3. Added `.gitignore` 
### File Changes
- Modified: `gazebo.launch` `gazebo.xacro` `bcr_bot.xacro`
- Added: `gitignore`
