### PR TITLE
ros2 fixed namespace updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ roslaunch bcr_bot rviz.launch
 The launch file accepts multiple launch arguments,
 ```bash
 roslaunch bcr_bot gazebo.launch 
-	camera_enabled:=True
-	two_d_lidar_enabled:=True
-	position_x:=0.0
-	position_y:=0.0
-	orientation_yaw:=0.0
+	camera_enabled:=True \
+	two_d_lidar_enabled:=True \
+	position_x:=0.0 \
+	position_y:=0.0 \
+	orientation_yaw:=0.0 \
+	odometry_source:=world \
 	world_file:=small_warehouse.world
 ```
 
@@ -88,13 +89,14 @@ ros2 launch bcr_bot rviz.launch.py
 
 The launch file accepts multiple launch arguments,
 ```bash
-ros2 launch bcr_bot gazebo.launch.py 
-	camera_enabled:=True
-	two_d_lidar_enabled:=True
-	position_x:=0.0
-	position_y:=0.0
-	orientation_yaw:=0.0
-	world_file:=small_warehouse.world
+ros2 launch bcr_bot gazebo.launch.py \
+	camera_enabled:=True \
+	two_d_lidar_enabled:=True \
+	position_x:=0.0 \
+	position_y:=0.0 \
+	orientation_yaw:=0.0 \
+	odometry_source:=world \
+	world_file:=small_warehouse.sdf
 ```
 
 ## Humble + Fortress (Ubuntu 22.04)
@@ -134,13 +136,13 @@ ros2 launch bcr_bot rviz.launch.py
 
 The launch file accepts multiple launch arguments,
 ```bash
-ros2 launch bcr_bot gz.launch.py 
-	camera_enabled:=True
-	two_d_lidar_enabled:=True
-	position_x:=0.0
-	position_y:=0.0
-	orientation_yaw:=0.0
-	world_file:=small_warehouse.world
+ros2 launch bcr_bot gz.launch.py \
+	camera_enabled:=True \
+	two_d_lidar_enabled:=True \
+	position_x:=0.0 \
+	position_y:=0.0  \
+	orientation_yaw:=0.0 \
+	world_file:=small_warehouse.sdf
 ```
 
 ### Simulation and Visualization

--- a/hooks/bcr_bot.sh.in
+++ b/hooks/bcr_bot.sh.in
@@ -4,9 +4,11 @@ if test -f "$GAZEBO_CLASSIC_SOURCE_FILE"; then
     source $GAZEBO_CLASSIC_SOURCE_FILE
     # Adding our models to the GAZEBO_MODEL_PATH
     ament_prepend_unique_value GAZEBO_MODEL_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+    ament_prepend_unique_value GAZEBO_RESOURCE_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
 fi
 
 GZ_FORTRESS_DIRECTORY=/usr/share/ignition
 if test -d "$GZ_FORTRESS_DIRECTORY"; then
     ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+    ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$COLCON_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
 fi

--- a/launch/gz.launch.py
+++ b/launch/gz.launch.py
@@ -21,7 +21,7 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time", default=True)
 
     bcr_bot_path = get_package_share_directory("bcr_bot")
-    world_file = LaunchConfiguration("world_file", default = "-r " + join(bcr_bot_path, "worlds", "small_warehouse.sdf"))
+    world_file = LaunchConfiguration("world_file", default = join(bcr_bot_path, "worlds", "small_warehouse.sdf"))
 
     position_x = LaunchConfiguration("position_x")
     position_y = LaunchConfiguration("position_y")
@@ -48,7 +48,10 @@ def generate_launch_description():
                     ' camera_enabled:=', camera_enabled,
                     ' two_d_lidar_enabled:=', two_d_lidar_enabled,
                     ' sim_gz:=', "true"
-                    ])}]
+                    ])}],
+        remappings=[
+            ('/joint_states', 'bcr_bot/joint_states'),
+        ]
     )
  
     gz_sim_share = get_package_share_directory("ros_gz_sim")
@@ -82,11 +85,22 @@ def generate_launch_description():
             "/odom@nav_msgs/msg/Odometry[ignition.msgs.Odometry",
             "/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V",
             "/scan@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan",
-            "/depth_camera@sensor_msgs/msg/Image[ignition.msgs.Image",
+            "/kinect_camera@sensor_msgs/msg/Image[ignition.msgs.Image",
             "/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
-            "/depth_camera/points@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked",
+            "/kinect_camera/points@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked",
             "/imu@sensor_msgs/msg/Imu[ignition.msgs.IMU",
+            "/world/default/model/bcr_bot/joint_state@sensor_msgs/msg/JointState[ignition.msgs.Model"
         ],
+        remappings=[
+            ('/world/default/model/bcr_bot/joint_state', 'bcr_bot/joint_states'),
+            ('/odom', 'bcr_bot/odom'),
+            ('/scan', 'bcr_bot/scan'),
+            ('/kinect_camera', 'bcr_bot/kinect_camera'),
+            ('/imu', 'bcr_bot/imu'),
+            ('/cmd_vel', 'bcr_bot/cmd_vel'),
+            ('/camera_info', 'bcr_bot/camera_info'),
+            ('/kinect_camera/points', 'bcr_bot/kinect_camera/points'),
+        ]
     )
 
     transform_publisher = Node(

--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -28,7 +28,7 @@
 <xacro:property name="two_d_lidar_sample_size"     value="361"/>
 <xacro:property name="two_d_lidar_min_angle"       value="0"/>
 <xacro:property name="two_d_lidar_max_angle"       value="360"/>
-<xacro:property name="two_d_lidar_min_range"       value="0.1"/>
+<xacro:property name="two_d_lidar_min_range"       value="0.55"/>
 <xacro:property name="two_d_lidar_max_range"       value="16"/>
 
 <xacro:property name="camera_baseline"             value="0.06"/>
@@ -44,6 +44,9 @@
 <xacro:arg      name="ground_truth_frame"          default="map"/>
 <xacro:arg      name="sim_gazebo"                  default="false" />
 <xacro:arg      name="sim_gz"                      default="false" />
+<xacro:arg      name="odometry_source"             default="world" />
+
+<xacro:property name="odometry_source"             value="$(arg odometry_source)"/>
 
 <!-- ............................... LOAD MACROS ................................. -->
 
@@ -132,7 +135,7 @@
    <joint name="two_d_lidar_joint" type="fixed">
       <parent link="base_link"/>
       <child link="two_d_lidar"/>
-      <origin xyz="0.3 0 0.08" rpy="0 0 0" />
+      <origin xyz="0.0 0 0.08" rpy="0 0 0" />
     </joint>
 
    <gazebo reference="two_d_lidar">

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -29,6 +29,13 @@
 		<publish_wheel_tf>true</publish_wheel_tf>
 		<publish_odom>true</publish_odom>
 		<max_wheel_acceleration>5.0</max_wheel_acceleration>
+		<!-- Odometry source, 0 for ENCODER, 1 for WORLD, defaults to WORLD -->
+		<xacro:if value="${odometry_source == 'world'}">
+			<odometry_source>1</odometry_source>
+		</xacro:if>
+		<xacro:if value="${odometry_source == 'encoder'}">
+			<odometry_source>0</odometry_source>
+		</xacro:if>
 	</plugin>
 </gazebo>
 
@@ -100,7 +107,7 @@
 					<remapping>~/out:=/$(arg robot_namespace)/scan</remapping>
 				</ros>
 				<output_type>sensor_msgs/LaserScan</output_type>
-				<frameName>two_d_lidar</frameName>
+				<frame_name>two_d_lidar</frame_name>
 			</plugin>
 		</sensor>
 	</gazebo>

--- a/urdf/gz.xacro
+++ b/urdf/gz.xacro
@@ -12,6 +12,10 @@
         name="ignition::gazebo::systems::Imu">
     </plugin>
 
+    <plugin filename="ignition-gazebo-joint-state-publisher-system" 
+        name="ignition::gazebo::systems::JointStatePublisher">
+    </plugin>
+
 <!-- ........................... DIFFERENTIAL DRIVE PLUGIN ................................... -->
 
     <plugin filename="ignition-gazebo-diff-drive-system" name="ignition::gazebo::systems::DiffDrive">
@@ -68,7 +72,7 @@
     <gazebo reference="kinect_camera">
         <sensor type="depth_camera" name="kinect_camera">
             <update_rate>30.0</update_rate>
-            <topic>depth_camera</topic>
+            <topic>kinect_camera</topic>
             <ignition_frame_id>kinect_camera</ignition_frame_id>
             <camera_info_topic>camera_info</camera_info_topic>
             <camera>


### PR DESCRIPTION
Pull Request:  add xacro argument for odometry_source, joint_state values are being published in ros2 ign gazebo

### Changes
1. Added plugin ignition-gazebo-joint-state-publisher-system" 
2. Added a new xacro argument called 'odometry_source' in the `bcr_bot.xacro` file to specify the `<odometry_source>` tag for the differential drive plugin of gazebo classic. This argument can be changed using a launch argument.

### File Changes
- Modified: `gazebo.launch.py` `gz.launch.py` `bcr_bot.xacro` `gazebo.xacro` `gz.xacro`  `readme.md`

### Modified File Details
1. `gazebo.launch.py`  remapping of joint_states to  bcr_bot/joint_states  and added odometry source as a launch argument.
2. `gz.launch.py` remapping of all the topics in gz_ros2_bridge to match them as classic gazebo 
3. `bcr_bot.xacro` added new xacro property odometry_source 
4. `gazebo.xacro` added <odometry_source> tag to diff_drive plugin
5. `gz.xacro` added new plugin ignition-gazebo-joint-state-publisher-system" 
6. `readme` roslaunch can be directly copy and pasted. odomentry_source as world and encoder 