### PR TITLE
robot_namespace fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ roslaunch bcr_bot gazebo.launch
 	position_y:=0.0 \
 	orientation_yaw:=0.0 \
 	odometry_source:=world \
-	world_file:=small_warehouse.world
+	world_file:=small_warehouse.world \
+	robot_namespace:="bcr_bot"
 ```
 
 ## Humble + Classic (Ubuntu 22.04)
@@ -96,7 +97,8 @@ ros2 launch bcr_bot gazebo.launch.py \
 	position_y:=0.0 \
 	orientation_yaw:=0.0 \
 	odometry_source:=world \
-	world_file:=small_warehouse.sdf
+	world_file:=small_warehouse.sdf \
+	robot_namespace:="bcr_bot"
 ```
 
 ## Humble + Fortress (Ubuntu 22.04)

--- a/launch/gazebo.launch.py
+++ b/launch/gazebo.launch.py
@@ -8,6 +8,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.substitutions import LaunchConfiguration, Command
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PythonExpression
 
 from launch_ros.actions import Node
 
@@ -28,6 +29,7 @@ def generate_launch_description():
     camera_enabled = LaunchConfiguration("camera_enabled", default=True)
     two_d_lidar_enabled = LaunchConfiguration("two_d_lidar_enabled", default=True)
     odometry_source = LaunchConfiguration("odometry_source", default="world")
+    robot_namespace = LaunchConfiguration("robot_namespace", default='')
     world_file = LaunchConfiguration("world_file", default = join(bcr_bot_path, 'worlds', 'small_warehouse.sdf'))
 
     # Path to the Xacro file
@@ -47,9 +49,10 @@ def generate_launch_description():
                     ' two_d_lidar_enabled:=', two_d_lidar_enabled,
                     ' sim_gazebo:=', "true",
                     ' odometry_source:=', odometry_source,
+                    ' robot_namespace:=', robot_namespace,
                     ])}],
         remappings=[
-            ('/joint_states', 'bcr_bot/joint_states'),
+            ('/joint_states', PythonExpression(['"', robot_namespace, '/joint_states"'])),
         ]
     )
 
@@ -60,7 +63,7 @@ def generate_launch_description():
         output='screen',
         arguments=[
             '-topic', "/robot_description",
-            '-entity', "bcr_bot",
+            '-entity', PythonExpression(['"', robot_namespace, '_robot"']), #default enitity name _bcr_bot
             '-z', "0.28",
             '-x', position_x,
             '-y', position_y,
@@ -85,7 +88,8 @@ def generate_launch_description():
         DeclareLaunchArgument("position_x", default_value="0.0"),
         DeclareLaunchArgument("position_y", default_value="0.0"),
         DeclareLaunchArgument("orientation_yaw", default_value="0.0"),
-        DeclareLaunchArgument("odometry_source", default_value = odometry_source),   
+        DeclareLaunchArgument("odometry_source", default_value = odometry_source),
+        DeclareLaunchArgument("robot_namespace", default_value = robot_namespace),    
         # DeclareLaunchArgument('robot_description', default_value=doc.toxml()),
         gazebo,
         robot_state_publisher,

--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -35,7 +35,7 @@
 <xacro:property name="camera_height"               value="0.10"/>
 <xacro:property name="camera_horizontal_fov"       value="60"/>
 
-<xacro:arg      name="robot_namespace"             default="bcr_bot"/>
+<xacro:arg      name="robot_namespace"             default=""/>
 <xacro:arg      name="wheel_odom_topic"            default="odom" />
 <xacro:arg      name="camera_enabled"              default="false" />
 <xacro:arg      name="two_d_lidar_enabled"         default="false" />

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -104,7 +104,7 @@
 			</ray>
 			<plugin name="gazebo_ros_laser" filename="libgazebo_ros_ray_sensor.so">
 				<ros>
-					<remapping>~/out:=/$(arg robot_namespace)/scan</remapping>
+					<remapping>~/out:=$(arg robot_namespace)/scan</remapping>
 				</ros>
 				<output_type>sensor_msgs/LaserScan</output_type>
 				<frame_name>two_d_lidar</frame_name>


### PR DESCRIPTION
## ROS2 branch changes 

### Default Robot Namespace
- The default robot_namespace for the Humble+Classic Gazebo package is now empty. 

### Default Entity Name
- The default entity name has been changed to "_robot".

### Updated Readme
- The readme file has been updated.

### Modified Files
The following files have been changed of the Humble+Classic Gazebo package:

- README.md
- launch/gazebo.launch.py
- urdf/bcr_bot.xacro
- urdf/gazebo.xacro