### PR TITLE
ros1-robot_namespace fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ roslaunch bcr_bot gazebo.launch \
 	position_y:=0.0 \
 	orientation_yaw:=0.0 \
 	odometry_source:=world \
-	world_file:=small_warehouse.world
+	world_file:=small_warehouse.world \
+	robot_namespace:="bcr_bot"
 ```
 
 ## Humble + Classic (Ubuntu 22.04)
@@ -94,7 +95,8 @@ ros2 launch bcr_bot gazebo.launch.py \
 	position_y:=0.0 \
 	orientation_yaw:=0.0 \
 	odometry_source:=world \
-	world_file:=small_warehouse.sdf
+	world_file:=small_warehouse.sdf \
+	robot_namespace:="bcr_bot"
 ```
 
 ## Humble + Fortress (Ubuntu 22.04)

--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -13,7 +13,7 @@
 <arg name="publish_wheel_odom_tf"	default="true"/>
 <arg name="conveyor_enabled"        default="false"/>
 <arg name="ground_truth_frame"      default="map"/>
-<arg name="robot_namespace"         default="bcr_bot"/>
+<arg name="robot_namespace"         default=""/>
 <arg name="world_name"              default="$(find bcr_bot)/worlds/small_warehouse.world"/>
 <arg name="position_x"              default="0.0"/>
 <arg name="position_y"              default="0.0"/>
@@ -50,7 +50,7 @@
 <node name="spawn_model" pkg="gazebo_ros" type="spawn_model"
 	args="-param robot_description
 		-urdf
-		-model $(arg robot_namespace)
+		-model $(arg robot_namespace)_robot
 		-x $(arg position_x)
         -y $(arg position_y)
 		-z 0.9

--- a/launch/rviz.launch
+++ b/launch/rviz.launch
@@ -14,8 +14,8 @@
 	camera_enabled:=$(arg camera_enabled)
 	" />
 
-<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+<!-- <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" /> -->
 
 <!-- ............................... RVIZ LAUNCH ..................................... -->
 


### PR DESCRIPTION
## ROS1 branch changes 

### Default Robot Namespace
- The default robot_namespace for the Noetic+Classic Gazebo package is now empty. 

### Default model Name
- The default entity name has been changed to "_robot".

### Updated Readme
- The readme file has been updated.

### rviz.launch
- Commented the part where rviz.launch was starting robot_state_publisher (it was fatal) 

### Modified Files
The following files have been changed of the noetic+Classic Gazebo package:
- README.md
- launch/gazebo.launch.py
- launch/rviz.launch.py