### PR TITLE
Merge Request for Issue #7 - Fixing Terminology in bcr_bot.xacro

### DIFF
--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -14,7 +14,7 @@
 <xacro:property name="traction_wheel_friction"     value="5.0"/>
 
 <xacro:property name="trolley_wheel_mass"          value="0.1"/>
-<xacro:property name="trolley_wheel_base"          value="0.54"/>
+<xacro:property name="trolley_track_width"          value="0.54"/>
 <xacro:property name="trolley_wheel_friction"      value="0.0"/>
 <xacro:property name="trolley_wheel_radius"        value="0.06"/>
 <!-- a small constant -->
@@ -22,7 +22,7 @@
 
 <xacro:property name="traction_wheel_radius"       value="0.1"/>
 <xacro:property name="traction_wheel_width"        value="0.05"/>
-<xacro:property name="traction_wheel_base"         value="0.8"/>
+<xacro:property name="traction_track_width"         value="0.8"/>
 
 <xacro:property name="two_d_lidar_update_rate"     value="30"/>
 <xacro:property name="two_d_lidar_sample_size"     value="361"/>
@@ -96,14 +96,14 @@
 
 <!-- ................................ WHEELS ..................................... -->
 
-<xacro:trolley_wheel cardinality="front" dexterity="left"  origin_x="${chassis_length/2}" origin_y="${trolley_wheel_base/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-<xacro:trolley_wheel cardinality="front" dexterity="right" origin_x="${chassis_length/2}" origin_y="-${trolley_wheel_base/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
+<xacro:trolley_wheel cardinality="front" dexterity="left"  origin_x="${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
+<xacro:trolley_wheel cardinality="front" dexterity="right" origin_x="${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
 
-<xacro:trolley_wheel cardinality="back" dexterity="left"  origin_x="-${chassis_length/2}" origin_y="${trolley_wheel_base/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-<xacro:trolley_wheel cardinality="back" dexterity="right" origin_x="-${chassis_length/2}" origin_y="-${trolley_wheel_base/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
+<xacro:trolley_wheel cardinality="back" dexterity="left"  origin_x="-${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
+<xacro:trolley_wheel cardinality="back" dexterity="right" origin_x="-${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
 
-<xacro:traction_wheel cardinality="middle" dexterity="left"  origin_x="0" origin_y="${traction_wheel_base/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
-<xacro:traction_wheel cardinality="middle" dexterity="right" origin_x="0" origin_y="-${traction_wheel_base/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
+<xacro:traction_wheel cardinality="middle" dexterity="left"  origin_x="0" origin_y="${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
+<xacro:traction_wheel cardinality="middle" dexterity="right" origin_x="0" origin_y="-${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
 
 <!-- ............................. 2D LIDAR ........................................ -->
 

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -18,7 +18,7 @@
 		<update_rate>50.0</update_rate>
 		<left_joint>middle_left_wheel_joint</left_joint>
 		<right_joint>middle_right_wheel_joint</right_joint>
-		<wheel_separation>${traction_wheel_base+traction_wheel_width-0.01}</wheel_separation>
+		<wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
 		<wheel_diameter>${2*traction_wheel_radius+0.01}</wheel_diameter>
 		<robot_base_frame>base_link</robot_base_frame>
 		<max_wheel_torque>${traction_max_wheel_torque}</max_wheel_torque>

--- a/urdf/gz.xacro
+++ b/urdf/gz.xacro
@@ -21,7 +21,7 @@
     <plugin filename="ignition-gazebo-diff-drive-system" name="ignition::gazebo::systems::DiffDrive">
         <left_joint>middle_left_wheel_joint</left_joint>
         <right_joint>middle_right_wheel_joint</right_joint>
-        <wheel_separation>${traction_wheel_base+traction_wheel_width-0.01}</wheel_separation>
+        <wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
         <wheel_radius>${traction_wheel_radius+0.01}</wheel_radius>
         <odom_publish_frequency>30</odom_publish_frequency>
         <topic>/cmd_vel</topic>


### PR DESCRIPTION
Description:
This merge request addresses Issue #7 and includes changes to the `bcr_bot.xacro` file to update the terminology related to wheel bases. The changes have been made to improve clarity and consistency in the codebase. Specifically, we have replaced instances of `trolley_wheel_base` with `trolley_track_width` and `traction_wheel_base` with `traction_track_width`.

Changes:
- Replaced occurrences of `trolley_wheel_base` with `trolley_track_width`.
- Updated overwritten `traction_wheel_base` to `traction_track_width`.

Files Changed:
- bcr_bot.xacro
- gazebo.xacro (diff drive plugin param)
- gz.xacro (diff drive plugin param)
