### PR TITLE
Add stereo camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ The launch file accepts multiple launch arguments,
 roslaunch bcr_bot gazebo.launch \
 	camera_enabled:=True \
 	two_d_lidar_enabled:=True \
+	stereo_camera_enabled:=True \
 	position_x:=0.0 \
 	position_y:=0.0 \
 	orientation_yaw:=0.0 \
 	odometry_source:=world \
 	world_file:=small_warehouse.world \
 	robot_namespace:="bcr_bot"
+```
+**Note:** To use stereo_image_proc with the stereo images excute following command: 
+```bash
+ROS_NAMESPACE=bcr_bot/stereo_camera rosrun stereo_image_proc stereo_image_proc
 ```
 
 ## Humble + Classic (Ubuntu 22.04)
@@ -91,6 +96,7 @@ The launch file accepts multiple launch arguments,
 ros2 launch bcr_bot gazebo.launch.py \
 	camera_enabled:=True \
 	two_d_lidar_enabled:=True \
+	stereo_camera_enabled:=False \
 	position_x:=0.0 \
 	position_y:=0.0 \
 	orientation_yaw:=0.0 \
@@ -98,7 +104,10 @@ ros2 launch bcr_bot gazebo.launch.py \
 	world_file:=small_warehouse.sdf \
 	robot_namespace:="bcr_bot"
 ```
-
+**Note:** To use stereo_image_proc with the stereo images excute following command: 
+```bash
+ros2 launch stereo_image_proc stereo_image_proc.launch.py left_namespace:=bcr_bot/stereo_camera/left right_namespace:=bcr_bot/stereo_camera/right
+```
 ## Humble + Fortress (Ubuntu 22.04)
 
 ### Dependencies
@@ -140,11 +149,14 @@ ros2 launch bcr_bot gz.launch.py \
 	camera_enabled:=True \
 	two_d_lidar_enabled:=True \
 	position_x:=0.0 \
-	position_y:=0.0 \
+	position_y:=0.0  \
 	orientation_yaw:=0.0 \
 	world_file:=small_warehouse.sdf
 ```
-
+**Note:** To use stereo_image_proc with the stereo images excute following command: 
+```bash
+ros2 launch stereo_image_proc stereo_image_proc.launch.py left_namespace:=bcr_bot/stereo_camera/left right_namespace:=bcr_bot/stereo_camera/right
+```
 ### Simulation and Visualization
 1. Gz Sim (Ignition Gazebo) (small_warehouse World):
 	![](res/gz.jpg)

--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -9,6 +9,7 @@
 <arg name="gazebo_gui_enabled" 		default="true"/>
 <arg name="two_d_lidar_enabled"		default="true"/>
 <arg name="camera_enabled"			default="true"/>
+<arg name="stereo_camera_enabled"	default="false"/>
 <arg name="wheel_odom_topic"		default="odom"/>
 <arg name="publish_wheel_odom_tf"	default="true"/>
 <arg name="conveyor_enabled"        default="false"/>
@@ -36,6 +37,7 @@
 <param name="robot_description" command="$(find xacro)/xacro $(find bcr_bot)/urdf/bcr_bot.xacro
 	two_d_lidar_enabled:=$(arg two_d_lidar_enabled)
 	camera_enabled:=$(arg camera_enabled)
+	stereo_camera_enabled:=$(arg stereo_camera_enabled)
 	wheel_odom_topic:=$(arg wheel_odom_topic)
 	publish_wheel_odom_tf:=$(arg publish_wheel_odom_tf)
 	conveyor_enabled:=$(arg conveyor_enabled)

--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -1,300 +1,300 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-<!--................................ XACRO CONSTANTS .............................. -->
+    <!--................................ XACRO CONSTANTS .............................. -->
 
-<xacro:property name="chassis_mass"                value="70"/>
-<xacro:property name="chassis_length"              value="0.9"/>
-<xacro:property name="chassis_width"               value="0.64"/>
-<xacro:property name="chassis_height"              value="0.19"/>
+    <xacro:property name="chassis_mass" value="70"/>
+    <xacro:property name="chassis_length" value="0.9"/>
+    <xacro:property name="chassis_width" value="0.64"/>
+    <xacro:property name="chassis_height" value="0.19"/>
 
-<xacro:property name="traction_wheel_mass"         value="1"/>
-<xacro:property name="traction_wheel_base"         value="0.88"/>
-<xacro:property name="traction_max_wheel_torque"   value="20000"/>
-<xacro:property name="traction_wheel_friction"     value="5.0"/>
+    <xacro:property name="traction_wheel_mass" value="1"/>
+    <xacro:property name="traction_wheel_base" value="0.88"/>
+    <xacro:property name="traction_max_wheel_torque" value="20000"/>
+    <xacro:property name="traction_wheel_friction" value="5.0"/>
 
-<xacro:property name="trolley_wheel_mass"          value="0.1"/>
-<xacro:property name="trolley_track_width"          value="0.54"/>
-<xacro:property name="trolley_wheel_friction"      value="0.0"/>
-<xacro:property name="trolley_wheel_radius"        value="0.06"/>
-<!-- a small constant -->
-<xacro:property name="eps"                         value="0.002"/>
+    <xacro:property name="trolley_wheel_mass" value="0.1"/>
+    <xacro:property name="trolley_track_width" value="0.54"/>
+    <xacro:property name="trolley_wheel_friction" value="0.0"/>
+    <xacro:property name="trolley_wheel_radius" value="0.06"/>
+    <!-- a small constant -->
+    <xacro:property name="eps" value="0.002"/>
 
-<xacro:property name="traction_wheel_radius"       value="0.1"/>
-<xacro:property name="traction_wheel_width"        value="0.05"/>
-<xacro:property name="traction_track_width"         value="0.8"/>
+    <xacro:property name="traction_wheel_radius" value="0.1"/>
+    <xacro:property name="traction_wheel_width" value="0.05"/>
+    <xacro:property name="traction_track_width" value="0.8"/>
 
-<xacro:property name="two_d_lidar_update_rate"     value="30"/>
-<xacro:property name="two_d_lidar_sample_size"     value="361"/>
-<xacro:property name="two_d_lidar_min_angle"       value="0"/>
-<xacro:property name="two_d_lidar_max_angle"       value="360"/>
-<xacro:property name="two_d_lidar_min_range"       value="0.55"/>
-<xacro:property name="two_d_lidar_max_range"       value="16"/>
+    <xacro:property name="two_d_lidar_update_rate" value="30"/>
+    <xacro:property name="two_d_lidar_sample_size" value="361"/>
+    <xacro:property name="two_d_lidar_min_angle" value="0"/>
+    <xacro:property name="two_d_lidar_max_angle" value="360"/>
+    <xacro:property name="two_d_lidar_min_range" value="0.55"/>
+    <xacro:property name="two_d_lidar_max_range" value="16"/>
 
-<xacro:property name="camera_baseline"             value="0.06"/>
-<xacro:property name="camera_height"               value="0.10"/>
-<xacro:property name="camera_horizontal_fov"       value="60"/>
+    <xacro:property name="camera_baseline" value="0.06"/>
+    <xacro:property name="camera_height" value="0.10"/>
+    <xacro:property name="camera_horizontal_fov" value="60"/>
 
-<xacro:arg      name="robot_namespace"             default="/"/>
-<xacro:arg      name="wheel_odom_topic"            default="odom"/>
-<xacro:arg      name="camera_enabled"              default="false"/>
-<xacro:arg      name="stereo_camera_enabled"       default="false" />
-<xacro:arg      name="two_d_lidar_enabled"         default="false"/>
-<xacro:arg      name="publish_wheel_odom_tf"       default="true"/>
-<xacro:arg      name="conveyor_enabled"            default="false"/>
-<xacro:arg      name="ground_truth_frame"          default="map"/>
-<xacro:arg      name="odometry_source"             default="world"/>
+    <xacro:arg name="robot_namespace" default="/"/>
+    <xacro:arg name="wheel_odom_topic" default="odom"/>
+    <xacro:arg name="camera_enabled" default="false"/>
+    <xacro:arg name="stereo_camera_enabled" default="false" />
+    <xacro:arg name="two_d_lidar_enabled" default="false"/>
+    <xacro:arg name="publish_wheel_odom_tf" default="true"/>
+    <xacro:arg name="conveyor_enabled" default="false"/>
+    <xacro:arg name="ground_truth_frame" default="map"/>
+    <xacro:arg name="odometry_source" default="world"/>
 
 
-<!-- ............................... LOAD MACROS ................................. -->
+    <!-- ............................... LOAD MACROS ................................. -->
 
-<xacro:include filename="$(find bcr_bot)/urdf/materials.xacro"/>
-<xacro:include filename="$(find bcr_bot)/urdf/macros.xacro"/>
-<xacro:include filename="$(find bcr_bot)/urdf/gazebo.xacro"/>
+    <xacro:include filename="$(find bcr_bot)/urdf/materials.xacro"/>
+    <xacro:include filename="$(find bcr_bot)/urdf/macros.xacro"/>
+    <xacro:include filename="$(find bcr_bot)/urdf/gazebo.xacro"/>
 
-<!-- ................................ BASE LINK .................................. -->
+    <!-- ................................ BASE LINK .................................. -->
 
-<link name="base_link"/>
+    <link name="base_link"/>
 
-<link name="chassis_link">
+    <link name="chassis_link">
 
-	<collision>
-		<origin xyz="0 0 -0.05" rpy="0 0 0" />
-  		<geometry>
-			<box size="${chassis_length} ${chassis_width} ${chassis_height}"/>
-  		</geometry>
-	</collision>
-
-	<visual>
-		<origin xyz="0 0 -0.2" rpy="0 0 0" />
-  		<geometry>
-    		<mesh filename="file://$(find bcr_bot)/meshes/bcr_bot_mesh.dae" scale="1 1 1"/>
-  		</geometry>
-	</visual>
-
-	<inertial>
-		<mass value="${chassis_mass}" />
-		<xacro:box_inertia m="${chassis_mass}" x="${chassis_length}" y="${chassis_width}" z = "${chassis_height}"/>
-	</inertial>
-
-</link>
-
-<joint name="chassis_joint" type="fixed">
-	<parent link="base_link"/>
-	<child link="chassis_link"/>
-	<origin xyz="0.0 0 0" rpy="0 0 0.0" />
-</joint>
-
-<!-- ................................ WHEELS ..................................... -->
-
-<xacro:trolley_wheel cardinality="front" dexterity="left"  origin_x="${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-<xacro:trolley_wheel cardinality="front" dexterity="right" origin_x="${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-
-<xacro:trolley_wheel cardinality="back" dexterity="left"  origin_x="-${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-<xacro:trolley_wheel cardinality="back" dexterity="right" origin_x="-${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-
-<xacro:traction_wheel cardinality="middle" dexterity="left"  origin_x="0" origin_y="${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
-<xacro:traction_wheel cardinality="middle" dexterity="right" origin_x="0" origin_y="-${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
-
-<!-- ............................. 2D LIDAR ........................................ -->
-
-<xacro:if value="$(arg two_d_lidar_enabled)">
-
-    <link name="two_d_lidar">
         <collision>
-          <origin xyz="0 0 0" rpy="0 0 0" />
-          <geometry>
-           <cylinder length="0.06" radius="0.075"/>
-          </geometry>
+            <origin xyz="0 0 -0.05" rpy="0 0 0" />
+            <geometry>
+                <box size="${chassis_length} ${chassis_width} ${chassis_height}"/>
+            </geometry>
         </collision>
 
         <visual>
-          <origin xyz="0 0 0" rpy="0 0 0" />
-          <geometry>
-           <cylinder length="0.06" radius="0.075"/>
-          </geometry>
-          <material name="aluminium"/>
+            <origin xyz="0 0 -0.2" rpy="0 0 0" />
+            <geometry>
+                <mesh filename="file://$(find bcr_bot)/meshes/bcr_bot_mesh.dae" scale="1 1 1"/>
+            </geometry>
         </visual>
 
         <inertial>
-          <origin xyz="0 0 0" rpy="0 0 0" />
-          <mass value="0.1"/>
-          <xacro:cylinder_inertia m="0.1" r="0.075" h="0.06"/>
+            <mass value="${chassis_mass}" />
+            <xacro:box_inertia m="${chassis_mass}" x="${chassis_length}" y="${chassis_width}" z = "${chassis_height}"/>
         </inertial>
-   </link>
 
-   <joint name="two_d_lidar_joint" type="fixed">
-      <parent link="base_link"/>
-      <child link="two_d_lidar"/>
-      <origin xyz="0 0 0.08" rpy="0 0 0" />
+    </link>
+
+    <joint name="chassis_joint" type="fixed">
+        <parent link="base_link"/>
+        <child link="chassis_link"/>
+        <origin xyz="0.0 0 0" rpy="0 0 0.0" />
     </joint>
 
-   <gazebo reference="two_d_lidar">
-       <material>Gazebo/White</material>
-   </gazebo>
+    <!-- ................................ WHEELS ..................................... -->
 
-</xacro:if>
+    <xacro:trolley_wheel cardinality="front" dexterity="left" origin_x="${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
+    <xacro:trolley_wheel cardinality="front" dexterity="right" origin_x="${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
 
-<!-- ............................. IMU ........................................ -->
+    <xacro:trolley_wheel cardinality="back" dexterity="left" origin_x="-${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
+    <xacro:trolley_wheel cardinality="back" dexterity="right" origin_x="-${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
 
-<link name="imu_frame"/>
+    <xacro:traction_wheel cardinality="middle" dexterity="left" origin_x="0" origin_y="${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
+    <xacro:traction_wheel cardinality="middle" dexterity="right" origin_x="0" origin_y="-${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
 
-<joint name="imu_joint" type="fixed">
-    <parent link="base_link"/>
-    <child link="imu_frame"/>
-    <origin xyz="0.0 0.0 0.08" rpy="0.0 0.0 0.0"/>
-</joint>
+    <!-- ............................. 2D LIDAR ........................................ -->
 
-<!-- ............................. CAMERA ........................................ -->
+    <xacro:if value="$(arg two_d_lidar_enabled)">
 
-<xacro:if value="$(arg camera_enabled)">
+        <link name="two_d_lidar">
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <cylinder length="0.06" radius="0.075"/>
+                </geometry>
+            </collision>
 
-	<!-- KINECT CAMERA -->
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <cylinder length="0.06" radius="0.075"/>
+                </geometry>
+                <material name="aluminium"/>
+            </visual>
 
-	<link name="kinect_camera">
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <mass value="0.1"/>
+                <xacro:cylinder_inertia m="0.1" r="0.075" h="0.06"/>
+            </inertial>
+        </link>
 
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-				<geometry>
-					<box size="0.07 0.3 0.09"/>
-				</geometry>
-		</collision>
+        <joint name="two_d_lidar_joint" type="fixed">
+            <parent link="base_link"/>
+            <child link="two_d_lidar"/>
+            <origin xyz="0 0 0.08" rpy="0 0 0" />
+        </joint>
 
-		<visual>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-				<geometry>
-					<mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
-				</geometry>
-				<material name="black"/>
-		</visual>
+        <gazebo reference="two_d_lidar">
+            <material>Gazebo/White</material>
+        </gazebo>
 
-		<inertial>
-				<mass value="0.01"/>
-				<xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
-		</inertial>
+    </xacro:if>
 
-	</link>
+    <!-- ............................. IMU ........................................ -->
 
-	<joint name="kinect_camera_joint" type="fixed">
-			<origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
-			<parent link="base_link"/>
-			<child link="kinect_camera"/>
-	</joint>
+    <link name="imu_frame"/>
 
-	<link name="kinect_camera_optical"/>
+    <joint name="imu_joint" type="fixed">
+        <parent link="base_link"/>
+        <child link="imu_frame"/>
+        <origin xyz="0.0 0.0 0.08" rpy="0.0 0.0 0.0"/>
+    </joint>
 
-	<joint name="kinect_camera_optical_joint" type="fixed">
-		<origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
-		<parent link="kinect_camera"/>
-		<child link="kinect_camera_optical"/>
-	</joint>
+    <!-- ............................. CAMERA ........................................ -->
 
-</xacro:if>
+    <xacro:if value="$(arg camera_enabled)">
 
-<!-- .............................. STEREO CAMERA ........................................ -->
+        <!-- KINECT CAMERA -->
 
-<xacro:if value="$(arg stereo_camera_enabled)">
+        <link name="kinect_camera">
 
-	<!-- STEREO CAMERA -->
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="0.07 0.3 0.09"/>
+                </geometry>
+            </collision>
 
-	<link name="stereo_camera">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
+                </geometry>
+                <material name="black"/>
+            </visual>
 
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-				<geometry>
-					<box size="0.07 0.3 0.09"/>
-				</geometry>
-		</collision>
+            <inertial>
+                <mass value="0.01"/>
+                <xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
+            </inertial>
 
-		<visual>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-				<geometry>
-					<mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
-				</geometry>
-				<material name="black"/>
-		</visual>
+        </link>
 
-		<inertial>
-				<mass value="0.01"/>
-				<xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
-		</inertial>
+        <joint name="kinect_camera_joint" type="fixed">
+            <origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
+            <parent link="base_link"/>
+            <child link="kinect_camera"/>
+        </joint>
 
-	</link>
+        <link name="kinect_camera_optical"/>
 
-	<joint name="stereo_camera_joint" type="fixed">
-			<origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
-			<parent link="base_link"/>
-			<child link="stereo_camera"/>
-	</joint>
+        <joint name="kinect_camera_optical_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+            <parent link="kinect_camera"/>
+            <child link="kinect_camera_optical"/>
+        </joint>
 
-	<link name="stereo_camera_optical"/>
+    </xacro:if>
 
-	<joint name="stereo_camera_optical_joint" type="fixed">
-		<origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
-		<parent link="stereo_camera"/>
-		<child link="stereo_camera_optical"/>
-	</joint>
+    <!-- .............................. STEREO CAMERA ........................................ -->
 
-</xacro:if>
+    <xacro:if value="$(arg stereo_camera_enabled)">
 
-<!-- ............................. ROOF ........................................ -->
+        <!-- STEREO CAMERA -->
 
-<link name="roof_link">
+        <link name="stereo_camera">
 
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-			<geometry>
-			<box size="${chassis_length} ${chassis_width} 0.015"/>
-			</geometry>
-		</collision>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="0.07 0.3 0.09"/>
+                </geometry>
+            </collision>
 
-		<inertial>
-			<mass value="1"/>
-			<xacro:box_inertia m="1" x="1" y="0.6" z = "0.015"/>
-		</inertial>
-	
-	</link>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
+                </geometry>
+                <material name="black"/>
+            </visual>
 
-	<joint name="roof joint" type="fixed">
-		<parent link="chassis_link"/>
-		<child link="roof_link"/>
-		<origin xyz="0 0 0.16" rpy="0 0 0" />
-	</joint>
+            <inertial>
+                <mass value="0.01"/>
+                <xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
+            </inertial>
 
-<!-- ............................. CONVEYOR ........................................ -->
+        </link>
 
-<xacro:if value="$(arg conveyor_enabled)">
+        <joint name="stereo_camera_joint" type="fixed">
+            <origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
+            <parent link="base_link"/>
+            <child link="stereo_camera"/>
+        </joint>
 
-	<link name="conveyor_belt">
+        <link name="stereo_camera_optical"/>
 
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-			<geometry>
-			<box size="1 0.6 0.015"/>
-			</geometry>
-		</collision>
+        <joint name="stereo_camera_optical_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+            <parent link="stereo_camera"/>
+            <child link="stereo_camera_optical"/>
+        </joint>
 
-		<visual>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-			<box size="1 0.6 0.015"/>
-			</geometry>
-		</visual>
+    </xacro:if>
 
-		<inertial>
-			<mass value="1"/>
-			<xacro:box_inertia m="1" x="1" y="0.6" z = "0.015"/>
-		</inertial>
-	
-	</link>
+    <!-- ............................. ROOF ........................................ -->
 
-	<joint name="conveyor_joint" type="fixed">
-		<parent link="base_link"/>
-		<child link="conveyor_belt"/>
-		<origin xyz="0 0 0.25" rpy="0 0 0" />
-	</joint>
+    <link name="roof_link">
 
-</xacro:if>
-<!-- ............................................................................... -->
+        <collision>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+                <box size="${chassis_length} ${chassis_width} 0.015"/>
+            </geometry>
+        </collision>
+
+        <inertial>
+            <mass value="1"/>
+            <xacro:box_inertia m="1" x="1" y="0.6" z = "0.015"/>
+        </inertial>
+
+    </link>
+
+    <joint name="roof joint" type="fixed">
+        <parent link="chassis_link"/>
+        <child link="roof_link"/>
+        <origin xyz="0 0 0.16" rpy="0 0 0" />
+    </joint>
+
+    <!-- ............................. CONVEYOR ........................................ -->
+
+    <xacro:if value="$(arg conveyor_enabled)">
+
+        <link name="conveyor_belt">
+
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="1 0.6 0.015"/>
+                </geometry>
+            </collision>
+
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <box size="1 0.6 0.015"/>
+                </geometry>
+            </visual>
+
+            <inertial>
+                <mass value="1"/>
+                <xacro:box_inertia m="1" x="1" y="0.6" z = "0.015"/>
+            </inertial>
+
+        </link>
+
+        <joint name="conveyor_joint" type="fixed">
+            <parent link="base_link"/>
+            <child link="conveyor_belt"/>
+            <origin xyz="0 0 0.25" rpy="0 0 0" />
+        </joint>
+
+    </xacro:if>
+    <!-- ............................................................................... -->
 
 </robot>

--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -38,6 +38,7 @@
 <xacro:arg      name="robot_namespace"             default="/"/>
 <xacro:arg      name="wheel_odom_topic"            default="odom"/>
 <xacro:arg      name="camera_enabled"              default="false"/>
+<xacro:arg      name="stereo_camera_enabled"       default="false" />
 <xacro:arg      name="two_d_lidar_enabled"         default="false"/>
 <xacro:arg      name="publish_wheel_odom_tf"       default="true"/>
 <xacro:arg      name="conveyor_enabled"            default="false"/>
@@ -186,6 +187,52 @@
 		<origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
 		<parent link="kinect_camera"/>
 		<child link="kinect_camera_optical"/>
+	</joint>
+
+</xacro:if>
+
+<!-- .............................. STEREO CAMERA ........................................ -->
+
+<xacro:if value="$(arg stereo_camera_enabled)">
+
+	<!-- STEREO CAMERA -->
+
+	<link name="stereo_camera">
+
+		<collision>
+			<origin xyz="0 0 0" rpy="0 0 0" />
+				<geometry>
+					<box size="0.07 0.3 0.09"/>
+				</geometry>
+		</collision>
+
+		<visual>
+			<origin xyz="0 0 0" rpy="0 0 0" />
+				<geometry>
+					<mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
+				</geometry>
+				<material name="black"/>
+		</visual>
+
+		<inertial>
+				<mass value="0.01"/>
+				<xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
+		</inertial>
+
+	</link>
+
+	<joint name="stereo_camera_joint" type="fixed">
+			<origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
+			<parent link="base_link"/>
+			<child link="stereo_camera"/>
+	</joint>
+
+	<link name="stereo_camera_optical"/>
+
+	<joint name="stereo_camera_optical_joint" type="fixed">
+		<origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+		<parent link="stereo_camera"/>
+		<child link="stereo_camera_optical"/>
 	</joint>
 
 </xacro:if>

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -36,12 +36,12 @@
 
 <gazebo reference="imu_frame">
 	<sensor name="my_imu" type="imu">
-    <always_on>true</always_on>
-    <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
-      <topicName>$(arg robot_namespace)/imu</topicName>
-      <updateRate>5</updateRate>
-      <frameName>imu_frame</frameName>
-    </plugin>
+	<always_on>true</always_on>
+	<plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+	  <topicName>$(arg robot_namespace)/imu</topicName>
+	  <updateRate>5</updateRate>
+	  <frameName>imu_frame</frameName>
+	</plugin>
   </sensor>
 </gazebo>
 
@@ -63,7 +63,7 @@
 
 <xacro:if value="$(arg two_d_lidar_enabled)">
 
-    <gazebo reference="two_d_lidar">
+	<gazebo reference="two_d_lidar">
 		<gravity>true</gravity>
 		<sensor type="ray" name="two_d_lidar">
 			<pose>0 0 0 0 0 0</pose>
@@ -95,7 +95,7 @@
 				<robotNamespace>$(arg robot_namespace)</robotNamespace>
 			</plugin>
 		</sensor>
-    </gazebo>
+	</gazebo>
 
 </xacro:if>
 
@@ -143,7 +143,65 @@
 
 </xacro:if>
 
-<!--................................................................................. -->
+<!-- ...........................STEREO CAMERA PLUGIN ................................... -->
 
+<xacro:if value="$(arg stereo_camera_enabled)">
+	<gazebo reference="stereo_camera">
+		<sensor type="multicamera" name="stereo_camera">
+			<update_rate>30.0</update_rate>
+
+			<camera name="left">
+				<horizontal_fov>1.3962634</horizontal_fov>
+				<image>
+				<width>800</width>
+				<height>800</height>
+				<format>R8G8B8</format>
+				</image>
+				<clip>
+				<near>0.3</near>
+				<far>20</far>
+				</clip>
+				<noise>
+				<type>gaussian</type>
+				<mean>0.0</mean>
+				<stddev>0.007</stddev>
+				</noise>
+			</camera>
+
+			<camera name="right">
+				<pose>0 -0.07 0 0 0 0</pose>
+				<horizontal_fov>1.3962634</horizontal_fov>
+				<image>
+				<width>800</width>
+				<height>800</height>
+				<format>R8G8B8</format>
+				</image>
+				<clip>
+				<near>0.3</near>
+				<far>20</far>
+				</clip>
+				<noise>
+				<type>gaussian</type>
+				<mean>0.0</mean>
+				<stddev>0.007</stddev>
+				</noise>
+			</camera>
+			
+			<plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
+				<alwaysOn>true</alwaysOn>
+				<updateRate>0.0</updateRate>
+				<cameraName>stereo_camera</cameraName>
+				<frameName>stereo_camera_optical</frameName>
+				<hackBaseline>0.07</hackBaseline>
+				<distortionK1>0.0</distortionK1>
+				<distortionK2>0.0</distortionK2>
+				<distortionK3>0.0</distortionK3>
+				<distortionT1>0.0</distortionT1>
+				<distortionT2>0.0</distortionT2>
+				<robotNamespace>$(arg robot_namespace)</robotNamespace>
+			</plugin>
+		</sensor>
+  </gazebo>
+</xacro:if>
 
 </robot>

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -1,207 +1,206 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-<gazebo>
-  <static>false</static>
-</gazebo>
+    <gazebo>
+        <static>false</static>
+    </gazebo>
 
+    <!-- .....................MULTI WHEEL DIFF DRIVE ................................... -->
 
-<!-- .....................MULTI WHEEL DIFF DRIVE ................................... -->
+    <gazebo>
+        <plugin name="diffdrive_plugin_multiwheel_middle" filename="libgazebo_ros_diff_drive.so">
+            <robotNamespace>$(arg robot_namespace)</robotNamespace>
+            <legacyMode>false</legacyMode>
+            <updateRate>50.0</updateRate>
+            <leftJoint>middle_left_wheel_joint</leftJoint>
+            <rightJoint>middle_right_wheel_joint</rightJoint>
+            <wheelSeparation>${traction_track_width+traction_wheel_width-0.01}</wheelSeparation>
+            <wheelDiameter>${2*traction_wheel_radius+0.01}</wheelDiameter>
+            <robotBaseFrame>base_link</robotBaseFrame>
+            <wheelTorque>${traction_max_wheel_torque}</wheelTorque>
+            <commandTopic>cmd_vel</commandTopic>
+            <odometryTopic>$(arg wheel_odom_topic)</odometryTopic>
+            <odometryFrame>odom</odometryFrame>
+            <rosDebugLevel>na</rosDebugLevel>
+            <publishOdomTF>$(arg publish_wheel_odom_tf)</publishOdomTF>
+            <publishWheelTF>false</publishWheelTF>
+            <publishWheelJointState>true</publishWheelJointState>
+            <publishOdometryMsg>true</publishOdometryMsg>
+            <odometrySource>$(arg odometry_source)</odometrySource>
+            <wheelAcceleration>5.0</wheelAcceleration>
+        </plugin>
+    </gazebo>
 
-<gazebo>
-	<plugin name="diffdrive_plugin_multiwheel_middle" filename="libgazebo_ros_diff_drive.so">
-		<robotNamespace>$(arg robot_namespace)</robotNamespace>
-		<legacyMode>false</legacyMode>
-		<updateRate>50.0</updateRate>
-		<leftJoint>middle_left_wheel_joint</leftJoint>
-		<rightJoint>middle_right_wheel_joint</rightJoint>
-		<wheelSeparation>${traction_track_width+traction_wheel_width-0.01}</wheelSeparation>
-		<wheelDiameter>${2*traction_wheel_radius+0.01}</wheelDiameter>
-		<robotBaseFrame>base_link</robotBaseFrame>
-		<wheelTorque>${traction_max_wheel_torque}</wheelTorque>
-		<commandTopic>cmd_vel</commandTopic>
-		<odometryTopic>$(arg wheel_odom_topic)</odometryTopic>
-		<odometryFrame>odom</odometryFrame>
-		<rosDebugLevel>na</rosDebugLevel>
-		<publishOdomTF>$(arg publish_wheel_odom_tf)</publishOdomTF>
-		<publishWheelTF>false</publishWheelTF>
-		<publishWheelJointState>true</publishWheelJointState>
-		<publishOdometryMsg>true</publishOdometryMsg>
-		<odometrySource>$(arg odometry_source)</odometrySource>
-		<wheelAcceleration>5.0</wheelAcceleration>
-	</plugin>
-</gazebo>
+    <!--............................... IMU PLUGIN ..................................... -->
 
-<!--............................... IMU PLUGIN ..................................... -->
+    <gazebo reference="imu_frame">
+        <sensor name="my_imu" type="imu">
+            <always_on>true</always_on>
+            <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+                <topicName>$(arg robot_namespace)/imu</topicName>
+                <updateRate>5</updateRate>
+                <frameName>imu_frame</frameName>
+            </plugin>
+        </sensor>
+    </gazebo>
 
-<gazebo reference="imu_frame">
-	<sensor name="my_imu" type="imu">
-	<always_on>true</always_on>
-	<plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
-	  <topicName>$(arg robot_namespace)/imu</topicName>
-	  <updateRate>5</updateRate>
-	  <frameName>imu_frame</frameName>
-	</plugin>
-  </sensor>
-</gazebo>
+    <!--............................... Ground truth PLUGIN .............................-->
 
-<!--............................... Ground truth PLUGIN .............................-->
+    <gazebo>
+        <plugin name="p3d_base_controller" filename="libgazebo_ros_p3d.so">
+            <robotNamespace>$(arg robot_namespace)</robotNamespace>
+            <alwaysOn>true</alwaysOn>
+            <updateRate>30.0</updateRate>
+            <bodyName>base_link</bodyName>
+            <topicName>ground_truth_pose</topicName>
+            <gaussianNoise>0.00</gaussianNoise>
+            <frameName>$(arg ground_truth_frame)</frameName>
+        </plugin>
+    </gazebo>
 
-<gazebo>
-	<plugin name="p3d_base_controller" filename="libgazebo_ros_p3d.so">
-		<robotNamespace>$(arg robot_namespace)</robotNamespace>
-		<alwaysOn>true</alwaysOn>
-		<updateRate>30.0</updateRate>
-		<bodyName>base_link</bodyName>
-		<topicName>ground_truth_pose</topicName>
-		<gaussianNoise>0.00</gaussianNoise>
-		<frameName>$(arg ground_truth_frame)</frameName>
-	</plugin>
-</gazebo>
+    <!-- ........................... 2D LIDAR PLUGIN ................................... -->
 
-<!-- ........................... 2D LIDAR PLUGIN ................................... -->
+    <xacro:if value="$(arg two_d_lidar_enabled)">
 
-<xacro:if value="$(arg two_d_lidar_enabled)">
+        <gazebo reference="two_d_lidar">
+            <gravity>true</gravity>
+            <sensor type="ray" name="two_d_lidar">
+                <pose>0 0 0 0 0 0</pose>
+                <visualize>false</visualize>
+                <update_rate>${two_d_lidar_update_rate}</update_rate>
+                <ray>
+                    <scan>
+                        <horizontal>
+                            <samples>${two_d_lidar_sample_size}</samples>
+                            <resolution>1</resolution>
+                            <min_angle>${radians(two_d_lidar_min_angle)}</min_angle>
+                            <max_angle>${radians(two_d_lidar_max_angle)}</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>${two_d_lidar_min_range}</min>
+                        <max>${two_d_lidar_max_range}</max>
+                        <resolution>0.01</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.001</stddev>
+                    </noise>
+                </ray>
+                <plugin name="gazebo_ros_laser" filename="libgazebo_ros_laser.so">
+                    <topicName>scan</topicName>
+                    <frameName>two_d_lidar</frameName>
+                    <robotNamespace>$(arg robot_namespace)</robotNamespace>
+                </plugin>
+            </sensor>
+        </gazebo>
 
-	<gazebo reference="two_d_lidar">
-		<gravity>true</gravity>
-		<sensor type="ray" name="two_d_lidar">
-			<pose>0 0 0 0 0 0</pose>
-			<visualize>false</visualize>
-			<update_rate>${two_d_lidar_update_rate}</update_rate>
-			<ray>
-				<scan>
-					<horizontal>
-						<samples>${two_d_lidar_sample_size}</samples>
-						<resolution>1</resolution>
-						<min_angle>${radians(two_d_lidar_min_angle)}</min_angle>
-						<max_angle>${radians(two_d_lidar_max_angle)}</max_angle>
-					</horizontal>
-				</scan>
-				<range>
-					<min>${two_d_lidar_min_range}</min>
-					<max>${two_d_lidar_max_range}</max>
-					<resolution>0.01</resolution>
-				</range>
-				<noise>
-					<type>gaussian</type>
-					<mean>0.0</mean>
-					<stddev>0.001</stddev>
-				</noise>
-			</ray>
-			<plugin name="gazebo_ros_laser" filename="libgazebo_ros_laser.so">
-				<topicName>scan</topicName>
-				<frameName>two_d_lidar</frameName>
-				<robotNamespace>$(arg robot_namespace)</robotNamespace>
-			</plugin>
-		</sensor>
-	</gazebo>
+    </xacro:if>
 
-</xacro:if>
+    <!-- ........................... CAMERA PLUGIN ................................... -->
 
-<!-- ........................... CAMERA PLUGIN ................................... -->
+    <xacro:if value="$(arg camera_enabled)">
 
-<xacro:if value="$(arg camera_enabled)">
+        <gazebo reference="kinect_camera">
+            <sensor type="depth" name="kinect_camera">
+                <always_on>true</always_on>
+                <update_rate>30.0</update_rate>
+                <camera>
+                    <horizontal_fov>${radians(camera_horizontal_fov)}</horizontal_fov>
+                    <image>
+                        <format>R8G8B8</format>
+                        <width>640</width>
+                        <height>480</height>
+                    </image>
+                    <clip>
+                        <near>0.05</near>
+                        <far>8.0</far>
+                    </clip>
+                </camera>
+                <plugin name="kinect_camera_controller" filename="libgazebo_ros_openni_kinect.so">
+                    <cameraName>kinect_camera</cameraName>
+                    <alwaysOn>true</alwaysOn>
+                    <updateRate>10</updateRate>
+                    <imageTopicName>rgb/image_raw</imageTopicName>
+                    <depthImageTopicName>depth/image_raw</depthImageTopicName>
+                    <pointCloudTopicName>depth/points</pointCloudTopicName>
+                    <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
+                    <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
+                    <frameName>kinect_camera_optical</frameName>
+                    <baseline>0.1</baseline>
+                    <distortion_k1>0.0</distortion_k1>
+                    <distortion_k2>0.0</distortion_k2>
+                    <distortion_k3>0.0</distortion_k3>
+                    <distortion_t1>0.0</distortion_t1>
+                    <distortion_t2>0.0</distortion_t2>
+                    <pointCloudCutoff>0.4</pointCloudCutoff>
+                    <robotNamespace>$(arg robot_namespace)</robotNamespace>
+                </plugin>
+            </sensor>
+        </gazebo>
 
-	<gazebo reference="kinect_camera">
-		<sensor type="depth" name="kinect_camera">
-			<always_on>true</always_on>
-			<update_rate>30.0</update_rate>
-			<camera>
-				<horizontal_fov>${radians(camera_horizontal_fov)}</horizontal_fov>
-				<image>
-					<format>R8G8B8</format>
-					<width>640</width>
-					<height>480</height>
-				</image>
-				<clip>
-					<near>0.05</near>
-					<far>8.0</far>
-				</clip>
-			</camera>
-			<plugin name="kinect_camera_controller" filename="libgazebo_ros_openni_kinect.so">
-				<cameraName>kinect_camera</cameraName>
-				<alwaysOn>true</alwaysOn>
-				<updateRate>10</updateRate>
-				<imageTopicName>rgb/image_raw</imageTopicName>
-				<depthImageTopicName>depth/image_raw</depthImageTopicName>
-				<pointCloudTopicName>depth/points</pointCloudTopicName>
-				<cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
-				<depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-				<frameName>kinect_camera_optical</frameName>
-				<baseline>0.1</baseline>
-				<distortion_k1>0.0</distortion_k1>
-				<distortion_k2>0.0</distortion_k2>
-				<distortion_k3>0.0</distortion_k3>
-				<distortion_t1>0.0</distortion_t1>
-				<distortion_t2>0.0</distortion_t2>
-				<pointCloudCutoff>0.4</pointCloudCutoff>
-				<robotNamespace>$(arg robot_namespace)</robotNamespace>
-			</plugin>
-		</sensor>
-	</gazebo>
+    </xacro:if>
 
-</xacro:if>
+    <!-- ...........................STEREO CAMERA PLUGIN ................................... -->
 
-<!-- ...........................STEREO CAMERA PLUGIN ................................... -->
+    <xacro:if value="$(arg stereo_camera_enabled)">
+        <gazebo reference="stereo_camera">
+            <sensor type="multicamera" name="stereo_camera">
+                <update_rate>30.0</update_rate>
 
-<xacro:if value="$(arg stereo_camera_enabled)">
-	<gazebo reference="stereo_camera">
-		<sensor type="multicamera" name="stereo_camera">
-			<update_rate>30.0</update_rate>
+                <camera name="left">
+                    <horizontal_fov>1.3962634</horizontal_fov>
+                    <image>
+                        <width>800</width>
+                        <height>800</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.3</near>
+                        <far>20</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.007</stddev>
+                    </noise>
+                </camera>
 
-			<camera name="left">
-				<horizontal_fov>1.3962634</horizontal_fov>
-				<image>
-				<width>800</width>
-				<height>800</height>
-				<format>R8G8B8</format>
-				</image>
-				<clip>
-				<near>0.3</near>
-				<far>20</far>
-				</clip>
-				<noise>
-				<type>gaussian</type>
-				<mean>0.0</mean>
-				<stddev>0.007</stddev>
-				</noise>
-			</camera>
+                <camera name="right">
+                    <pose>0 -0.07 0 0 0 0</pose>
+                    <horizontal_fov>1.3962634</horizontal_fov>
+                    <image>
+                        <width>800</width>
+                        <height>800</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.3</near>
+                        <far>20</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.007</stddev>
+                    </noise>
+                </camera>
 
-			<camera name="right">
-				<pose>0 -0.07 0 0 0 0</pose>
-				<horizontal_fov>1.3962634</horizontal_fov>
-				<image>
-				<width>800</width>
-				<height>800</height>
-				<format>R8G8B8</format>
-				</image>
-				<clip>
-				<near>0.3</near>
-				<far>20</far>
-				</clip>
-				<noise>
-				<type>gaussian</type>
-				<mean>0.0</mean>
-				<stddev>0.007</stddev>
-				</noise>
-			</camera>
-			
-			<plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
-				<alwaysOn>true</alwaysOn>
-				<updateRate>0.0</updateRate>
-				<cameraName>stereo_camera</cameraName>
-				<frameName>stereo_camera_optical</frameName>
-				<hackBaseline>0.07</hackBaseline>
-				<distortionK1>0.0</distortionK1>
-				<distortionK2>0.0</distortionK2>
-				<distortionK3>0.0</distortionK3>
-				<distortionT1>0.0</distortionT1>
-				<distortionT2>0.0</distortionT2>
-				<robotNamespace>$(arg robot_namespace)</robotNamespace>
-			</plugin>
-		</sensor>
-  </gazebo>
-</xacro:if>
+                <plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
+                    <alwaysOn>true</alwaysOn>
+                    <updateRate>0.0</updateRate>
+                    <cameraName>stereo_camera</cameraName>
+                    <frameName>stereo_camera_optical</frameName>
+                    <hackBaseline>0.07</hackBaseline>
+                    <distortionK1>0.0</distortionK1>
+                    <distortionK2>0.0</distortionK2>
+                    <distortionK3>0.0</distortionK3>
+                    <distortionT1>0.0</distortionT1>
+                    <distortionT2>0.0</distortionT2>
+                    <robotNamespace>$(arg robot_namespace)</robotNamespace>
+                </plugin>
+            </sensor>
+        </gazebo>
+    </xacro:if>
 
 </robot>

--- a/urdf/macros.xacro
+++ b/urdf/macros.xacro
@@ -1,94 +1,85 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-<!--................................ INERTIA MATRICES .............................. -->
+    <!--................................ INERTIA MATRICES .............................. -->
 
-<xacro:macro name="cylinder_inertia" params="m r h">
-	<inertia ixx="${m * (3 * r * r + h * h) / 12}" ixy="0" ixz="0"
-		iyy="${m * (3 * r * r + h * h) / 12}" iyz="0"
-		izz="${m * r * r / 2}"
-	/>
-</xacro:macro>
+    <xacro:macro name="cylinder_inertia" params="m r h">
+        <inertia ixx="${m * (3 * r * r + h * h) / 12}" ixy="0" ixz="0" iyy="${m * (3 * r * r + h * h) / 12}" iyz="0" izz="${m * r * r / 2}" />
+    </xacro:macro>
 
-<xacro:macro name="box_inertia" params="m x y z">
-	<inertia ixx="${m * (y * y + z * z) / 12}" ixy="0" ixz="0"
-		iyy="${m * (x * x + z * z) / 12}" iyz="0"
-		izz="${m * (y * y + x * x) / 12}"
-	/>
-</xacro:macro>
+    <xacro:macro name="box_inertia" params="m x y z">
+        <inertia ixx="${m * (y * y + z * z) / 12}" ixy="0" ixz="0" iyy="${m * (x * x + z * z) / 12}" iyz="0" izz="${m * (y * y + x * x) / 12}" />
+    </xacro:macro>
 
-<xacro:macro name="sphere_inertia" params="m r">
-	<inertia ixx="${2 * m * r * r / 5}" ixy="0" ixz="0"
-	iyy="${2 * m * r * r / 5}" iyz="0"
-	izz="${2 * m * r * r / 5}"
-	/>
-</xacro:macro>
+    <xacro:macro name="sphere_inertia" params="m r">
+        <inertia ixx="${2 * m * r * r / 5}" ixy="0" ixz="0" iyy="${2 * m * r * r / 5}" iyz="0" izz="${2 * m * r * r / 5}" />
+    </xacro:macro>
 
-<!-- ............................... TROLLEY WHEEL DEFINITION .............................. -->
+    <!-- ............................... TROLLEY WHEEL DEFINITION .............................. -->
 
-<xacro:macro name="trolley_wheel" params="cardinality dexterity origin_x origin_y origin_z">
+    <xacro:macro name="trolley_wheel" params="cardinality dexterity origin_x origin_y origin_z">
 
-	<link name="${cardinality}_${dexterity}_wheel">
-		<collision>
-			<origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
-			<geometry>
-				<sphere radius="${trolley_wheel_radius}"/>
-			</geometry>
-		</collision>
+        <link name="${cardinality}_${dexterity}_wheel">
+            <collision>
+                <origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
+                <geometry>
+                    <sphere radius="${trolley_wheel_radius}"/>
+                </geometry>
+            </collision>
 
-		<inertial>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-			<mass value="${trolley_wheel_mass}"/>
-			<xacro:sphere_inertia m="${trolley_wheel_mass}" r="${trolley_wheel_radius}"/>
-		</inertial>
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <mass value="${trolley_wheel_mass}"/>
+                <xacro:sphere_inertia m="${trolley_wheel_mass}" r="${trolley_wheel_radius}"/>
+            </inertial>
 
-		<mu>0.0</mu>
-	</link>
+            <mu>0.0</mu>
+        </link>
 
-	<joint name="${cardinality}_${dexterity}_wheel_joint" type="fixed">
-		<parent link="base_link"/>
-		<child link="${cardinality}_${dexterity}_wheel"/>
-		<origin xyz="${origin_x} ${origin_y} ${origin_z}" rpy="0 0 0" />
-		<axis xyz="0 1 0" rpy="0 0 0" />
-	</joint>
+        <joint name="${cardinality}_${dexterity}_wheel_joint" type="fixed">
+            <parent link="base_link"/>
+            <child link="${cardinality}_${dexterity}_wheel"/>
+            <origin xyz="${origin_x} ${origin_y} ${origin_z}" rpy="0 0 0" />
+            <axis xyz="0 1 0" rpy="0 0 0" />
+        </joint>
 
-	<gazebo reference="${cardinality}_${dexterity}_wheel">
-		<material>Gazebo/Black</material>
-	</gazebo>
+        <gazebo reference="${cardinality}_${dexterity}_wheel">
+            <material>Gazebo/Black</material>
+        </gazebo>
 
-</xacro:macro>
+    </xacro:macro>
 
 
-<xacro:macro name="traction_wheel" params="cardinality dexterity origin_x origin_y origin_z">
+    <xacro:macro name="traction_wheel" params="cardinality dexterity origin_x origin_y origin_z">
 
-	<link name="${cardinality}_${dexterity}_wheel">
-		<collision>
-			<origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
-			<geometry>
-				<cylinder length="${traction_wheel_width}" radius="${traction_wheel_radius}"/>
-			</geometry>
-		</collision>
+        <link name="${cardinality}_${dexterity}_wheel">
+            <collision>
+                <origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
+                <geometry>
+                    <cylinder length="${traction_wheel_width}" radius="${traction_wheel_radius}"/>
+                </geometry>
+            </collision>
 
-		<inertial>
-			<origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
-			<mass value="${traction_wheel_mass}"/>
-			<xacro:cylinder_inertia m="${traction_wheel_mass}" r="${traction_wheel_radius}" h="${traction_wheel_width}"/>
-		</inertial>
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
+                <mass value="${traction_wheel_mass}"/>
+                <xacro:cylinder_inertia m="${traction_wheel_mass}" r="${traction_wheel_radius}" h="${traction_wheel_width}"/>
+            </inertial>
 
-		<mu>5.0</mu>
-	</link>
+            <mu>5.0</mu>
+        </link>
 
-	<joint name="${cardinality}_${dexterity}_wheel_joint" type="continuous">
-		<parent link="base_link"/>
-		<child link="${cardinality}_${dexterity}_wheel"/>
-		<origin xyz="${origin_x} ${origin_y} ${origin_z}" rpy="0 0 0" />
-		<axis xyz="0 1 0" rpy="0 0 0" />
-	</joint>
+        <joint name="${cardinality}_${dexterity}_wheel_joint" type="continuous">
+            <parent link="base_link"/>
+            <child link="${cardinality}_${dexterity}_wheel"/>
+            <origin xyz="${origin_x} ${origin_y} ${origin_z}" rpy="0 0 0" />
+            <axis xyz="0 1 0" rpy="0 0 0" />
+        </joint>
 
-	<gazebo reference="${cardinality}_${dexterity}_wheel">
-		<material>Gazebo/Black</material>
-	</gazebo>
+        <gazebo reference="${cardinality}_${dexterity}_wheel">
+            <material>Gazebo/Black</material>
+        </gazebo>
 
-</xacro:macro>
+    </xacro:macro>
 
 </robot>

--- a/urdf/materials.xacro
+++ b/urdf/materials.xacro
@@ -1,56 +1,56 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-<material name="black">
-	<color rgba="0.0 0.0 0.0 1.0"/>
-</material>
+    <material name="black">
+        <color rgba="0.0 0.0 0.0 1.0"/>
+    </material>
 
-<material name="blue">
-	<color rgba="0.0 0.0 0.8 1.0"/>
-</material>
+    <material name="blue">
+        <color rgba="0.0 0.0 0.8 1.0"/>
+    </material>
 
-<material name="green">
-	<color rgba="0.0 0.8 0.0 1.0"/>
-</material>
+    <material name="green">
+        <color rgba="0.0 0.8 0.0 1.0"/>
+    </material>
 
-<material name="yellow">
-	<color rgba="1.0 1.0 0.0 1.0"/>
-</material>
+    <material name="yellow">
+        <color rgba="1.0 1.0 0.0 1.0"/>
+    </material>
 
-<material name="dark_grey">
-	<color rgba="0.2 0.2 0.2 1.0"/>
-</material>
+    <material name="dark_grey">
+        <color rgba="0.2 0.2 0.2 1.0"/>
+    </material>
 
-<material name="orange">
-	<color rgba="${255/255} ${108/255} ${10/255} 1.0"/>
-</material>
+    <material name="orange">
+        <color rgba="${255/255} ${108/255} ${10/255} 1.0"/>
+    </material>
 
-<material name="brown">
-	<color rgba="${139/255} ${69/255} ${19/255} 1.0"/>
-</material>
+    <material name="brown">
+        <color rgba="${139/255} ${69/255} ${19/255} 1.0"/>
+    </material>
 
-<material name="red">
-	<color rgba="0.8 0.0 0.0 1.0"/>
-</material>
+    <material name="red">
+        <color rgba="0.8 0.0 0.0 1.0"/>
+    </material>
 
-<material name="turquoise">
-	<color rgba="${64/255} ${224/255} ${208/255} 1.0"/>
-</material>
+    <material name="turquoise">
+        <color rgba="${64/255} ${224/255} ${208/255} 1.0"/>
+    </material>
 
-<material name="purple">
-	<color rgba="${128/255} ${0/255} ${128/255} 1.0"/>
-</material>
+    <material name="purple">
+        <color rgba="${128/255} ${0/255} ${128/255} 1.0"/>
+    </material>
 
-<material name="white">
-	<color rgba="1.0 1.0 1.0 1.0"/>
-</material>
+    <material name="white">
+        <color rgba="1.0 1.0 1.0 1.0"/>
+    </material>
 
-<material name="aluminium">
-	<color rgba="0.5 0.5 0.5 1"/>
-</material>
+    <material name="aluminium">
+        <color rgba="0.5 0.5 0.5 1"/>
+    </material>
 
-<material name="plastic">
-	<color rgba="0.1 0.1 0.1 1"/>
-</material>
+    <material name="plastic">
+        <color rgba="0.1 0.1 0.1 1"/>
+    </material>
 
 </robot>


### PR DESCRIPTION
**Description:**
This pull request adds stereo camera to the `bcr_bot` 

**Files Changed:**

1. **README.md:**
   - Updated the README.md file to include information about the added stereo camera and its usage.

2. **launch/gazebo.launch:**
   - Modified the `gazebo.launch` file to include the stereo camera in the robot's launch configuration.

3. **urdf/bcr_bot.xacro:**
   - Added a new link and joint for the stereo camera to the `bcr_bot` URDF model.
  
4. **urdf/gazebo.xacro:**
   - Added the stereo camera plugin to the `gazebo.xacro` 


**Testing:**
- Tested the changes with stereo_image_proc 