### PR TITLE
Add stereo camera to bcr_bot ros2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://github.com/blackcoffeerobotics/bcr_bot/assets/13151010/0fc570a3-c70c-415
 
 ## About
 
-This repository contains a Gazebo simulation for a differential drive robot, equipped with an IMU, a depth camera and a 2D LiDAR. The primary contriution of this project is to support multiple ROS and Gazebo distros. Currently, the project supports the following versions - 
+This repository contains a Gazebo simulation for a differential drive robot, equipped with an IMU, a depth camera, stereo camera and a 2D LiDAR. The primary contriution of this project is to support multiple ROS and Gazebo distros. Currently, the project supports the following versions - 
 
 1. [ROS Noetic + Gazebo Classic 11 (branch ros1)](#noetic--classic-ubuntu-2004)
 2. [ROS2 Humble + Gazebo Classic 11 (branch ros2)](#humble--classic-ubuntu-2204)
@@ -53,6 +53,10 @@ roslaunch bcr_bot gazebo.launch
 	world_file:=small_warehouse.world \
 	robot_namespace:="bcr_bot"
 ```
+**Note:** To use stereo_image_proc with the stereo images excute following command: 
+```bash
+ROS_NAMESPACE=bcr_bot/stereo_camera rosrun stereo_image_proc stereo_image_proc
+```
 
 ## Humble + Classic (Ubuntu 22.04)
 
@@ -93,6 +97,7 @@ The launch file accepts multiple launch arguments,
 ros2 launch bcr_bot gazebo.launch.py \
 	camera_enabled:=True \
 	two_d_lidar_enabled:=True \
+	stereo_camera_enabled:=False \
 	position_x:=0.0 \
 	position_y:=0.0 \
 	orientation_yaw:=0.0 \
@@ -100,7 +105,10 @@ ros2 launch bcr_bot gazebo.launch.py \
 	world_file:=small_warehouse.sdf \
 	robot_namespace:="bcr_bot"
 ```
-
+**Note:** To use stereo_image_proc with the stereo images excute following command: 
+```bash
+ros2 launch stereo_image_proc stereo_image_proc.launch.py left_namespace:=bcr_bot/stereo_camera/left right_namespace:=bcr_bot/stereo_camera/right
+```
 ## Humble + Fortress (Ubuntu 22.04)
 
 ### Dependencies
@@ -140,13 +148,17 @@ The launch file accepts multiple launch arguments,
 ```bash
 ros2 launch bcr_bot gz.launch.py \
 	camera_enabled:=True \
+	stereo_camera_enabled:=False \
 	two_d_lidar_enabled:=True \
 	position_x:=0.0 \
 	position_y:=0.0  \
 	orientation_yaw:=0.0 \
 	world_file:=small_warehouse.sdf
 ```
-
+**Note:** To use stereo_image_proc with the stereo images excute following command: 
+```bash
+ros2 launch stereo_image_proc stereo_image_proc.launch.py left_namespace:=bcr_bot/stereo_camera/left right_namespace:=bcr_bot/stereo_camera/right
+```
 ### Simulation and Visualization
 1. Gz Sim (Ignition Gazebo) (small_warehouse World):
 	![](res/gz.jpg)

--- a/launch/gazebo.launch.py
+++ b/launch/gazebo.launch.py
@@ -27,10 +27,12 @@ def generate_launch_description():
     position_y = LaunchConfiguration("position_y")
     orientation_yaw = LaunchConfiguration("orientation_yaw")
     camera_enabled = LaunchConfiguration("camera_enabled", default=True)
+    stereo_camera_enabled = LaunchConfiguration("stereo_camera_enabled", default=False)
     two_d_lidar_enabled = LaunchConfiguration("two_d_lidar_enabled", default=True)
     odometry_source = LaunchConfiguration("odometry_source", default="world")
     robot_namespace = LaunchConfiguration("robot_namespace", default='')
     world_file = LaunchConfiguration("world_file", default = join(bcr_bot_path, 'worlds', 'small_warehouse.sdf'))
+    
 
     # Path to the Xacro file
     xacro_path = join(bcr_bot_path, 'urdf', 'bcr_bot.xacro')
@@ -46,6 +48,7 @@ def generate_launch_description():
                     {'robot_description': Command( \
                     ['xacro ', xacro_path,
                     ' camera_enabled:=', camera_enabled,
+                    ' stereo_camera_enabled:=', stereo_camera_enabled,
                     ' two_d_lidar_enabled:=', two_d_lidar_enabled,
                     ' sim_gazebo:=', "true",
                     ' odometry_source:=', odometry_source,
@@ -84,12 +87,13 @@ def generate_launch_description():
         DeclareLaunchArgument('verbose', default_value='false'),
         DeclareLaunchArgument('use_sim_time', default_value = use_sim_time),
         DeclareLaunchArgument("camera_enabled", default_value = camera_enabled),
+        DeclareLaunchArgument("stereo_camera_enabled", default_value = stereo_camera_enabled),
         DeclareLaunchArgument("two_d_lidar_enabled", default_value = two_d_lidar_enabled),
         DeclareLaunchArgument("position_x", default_value="0.0"),
         DeclareLaunchArgument("position_y", default_value="0.0"),
         DeclareLaunchArgument("orientation_yaw", default_value="0.0"),
         DeclareLaunchArgument("odometry_source", default_value = odometry_source),
-        DeclareLaunchArgument("robot_namespace", default_value = robot_namespace),    
+        DeclareLaunchArgument("robot_namespace", default_value = robot_namespace),
         # DeclareLaunchArgument('robot_description', default_value=doc.toxml()),
         gazebo,
         robot_state_publisher,

--- a/launch/gz.launch.py
+++ b/launch/gz.launch.py
@@ -27,6 +27,7 @@ def generate_launch_description():
     position_y = LaunchConfiguration("position_y")
     orientation_yaw = LaunchConfiguration("orientation_yaw")
     camera_enabled = LaunchConfiguration("camera_enabled", default=True)
+    stereo_camera_enabled = LaunchConfiguration("stereo_camera_enabled", default=False)
     two_d_lidar_enabled = LaunchConfiguration("two_d_lidar_enabled", default=True)
 
     # robot_description_content = get_xacro_to_doc(
@@ -46,6 +47,7 @@ def generate_launch_description():
                     {'robot_description': Command( \
                     ['xacro ', join(bcr_bot_path, 'urdf/bcr_bot.xacro'),
                     ' camera_enabled:=', camera_enabled,
+                    ' stereo_camera_enabled:=', stereo_camera_enabled,
                     ' two_d_lidar_enabled:=', two_d_lidar_enabled,
                     ' sim_gz:=', "true"
                     ])}],
@@ -86,7 +88,11 @@ def generate_launch_description():
             "/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V",
             "/scan@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan",
             "/kinect_camera@sensor_msgs/msg/Image[ignition.msgs.Image",
-            "/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
+            "/stereo_camera/left/image_raw@sensor_msgs/msg/Image[ignition.msgs.Image",
+            "stereo_camera/right/image_raw@sensor_msgs/msg/Image[ignition.msgs.Image",
+            "kinect_camera/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
+            "stereo_camera/left/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
+            "stereo_camera/right/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
             "/kinect_camera/points@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked",
             "/imu@sensor_msgs/msg/Imu[ignition.msgs.IMU",
             "/world/default/model/bcr_bot/joint_state@sensor_msgs/msg/JointState[ignition.msgs.Model"
@@ -96,9 +102,13 @@ def generate_launch_description():
             ('/odom', 'bcr_bot/odom'),
             ('/scan', 'bcr_bot/scan'),
             ('/kinect_camera', 'bcr_bot/kinect_camera'),
+            ('/stereo_camera/left/image_raw', 'bcr_bot/stereo_camera/left/image_raw'),
+            ('/stereo_camera/right/image_raw', 'bcr_bot/stereo_camera/right/image_raw'),
             ('/imu', 'bcr_bot/imu'),
             ('/cmd_vel', 'bcr_bot/cmd_vel'),
-            ('/camera_info', 'bcr_bot/camera_info'),
+            ('kinect_camera/camera_info', 'bcr_bot/kinect_camera/camera_info'),
+            ('stereo_camera/left/camera_info', 'bcr_bot/stereo_camera/left/camera_info'),
+            ('stereo_camera/right/camera_info', 'bcr_bot/stereo_camera/right/camera_info'),
             ('/kinect_camera/points', 'bcr_bot/kinect_camera/points'),
         ]
     )
@@ -120,6 +130,7 @@ def generate_launch_description():
         DeclareLaunchArgument("use_sim_time", default_value=use_sim_time),
         DeclareLaunchArgument("world_file", default_value=world_file),
         DeclareLaunchArgument("camera_enabled", default_value = camera_enabled),
+        DeclareLaunchArgument("stereo_camera_enabled", default_value = stereo_camera_enabled),
         DeclareLaunchArgument("two_d_lidar_enabled", default_value = two_d_lidar_enabled),
         DeclareLaunchArgument("position_x", default_value="0.0"),
         DeclareLaunchArgument("position_y", default_value="0.0"),

--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -38,6 +38,7 @@
 <xacro:arg      name="robot_namespace"             default=""/>
 <xacro:arg      name="wheel_odom_topic"            default="odom" />
 <xacro:arg      name="camera_enabled"              default="false" />
+<xacro:arg      name="stereo_camera_enabled"       default="false" />
 <xacro:arg      name="two_d_lidar_enabled"         default="false" />
 <xacro:arg      name="publish_wheel_odom_tf"       default="true" />
 <xacro:arg      name="conveyor_enabled"            default="false"/>
@@ -196,6 +197,54 @@
 		<origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
 		<parent link="kinect_camera"/>
 		<child link="kinect_camera_optical"/>
+	</joint>
+
+</xacro:if>
+
+
+
+<!-- .............................STEREO CAMERA ........................................ -->
+
+<xacro:if value="$(arg stereo_camera_enabled)">
+
+	<!-- STEREO CAMERA -->
+
+	<link name="stereo_camera">
+
+		<collision>
+			<origin xyz="0 0 0" rpy="0 0 0" />
+				<geometry>
+					<box size="0.07 0.3 0.09"/>
+				</geometry>
+		</collision>
+
+		<visual>
+			<origin xyz="0 0 0" rpy="0 0 0" />
+				<geometry>
+					<mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
+				</geometry>
+				<material name="black"/>
+		</visual>
+
+		<inertial>
+				<mass value="0.01"/>
+				<xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
+		</inertial>
+
+	</link>
+
+	<joint name="stereo_camera_joint" type="fixed">
+			<origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
+			<parent link="base_link"/>
+			<child link="stereo_camera"/>
+	</joint>
+
+	<link name="stereo_camera_optical"/>
+
+	<joint name="stereo_camera_optical_joint" type="fixed">
+		<origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+		<parent link="stereo_camera"/>
+		<child link="stereo_camera_optical"/>
 	</joint>
 
 </xacro:if>

--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -1,312 +1,310 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-<!--................................ XACRO CONSTANTS .............................. -->
+    <!--................................ XACRO CONSTANTS .............................. -->
 
-<xacro:property name="chassis_mass"                value="70"/>
-<xacro:property name="chassis_length"              value="0.9"/>
-<xacro:property name="chassis_width"               value="0.64"/>
-<xacro:property name="chassis_height"              value="0.19"/>
+    <xacro:property name="chassis_mass" value="70"/>
+    <xacro:property name="chassis_length" value="0.9"/>
+    <xacro:property name="chassis_width" value="0.64"/>
+    <xacro:property name="chassis_height" value="0.19"/>
 
-<xacro:property name="traction_wheel_mass"         value="1"/>
-<xacro:property name="traction_wheel_base"         value="0.88"/>
-<xacro:property name="traction_max_wheel_torque"   value="20000"/>
-<xacro:property name="traction_wheel_friction"     value="5.0"/>
+    <xacro:property name="traction_wheel_mass" value="1"/>
+    <xacro:property name="traction_wheel_base" value="0.88"/>
+    <xacro:property name="traction_max_wheel_torque" value="20000"/>
+    <xacro:property name="traction_wheel_friction" value="5.0"/>
 
-<xacro:property name="trolley_wheel_mass"          value="0.1"/>
-<xacro:property name="trolley_track_width"          value="0.54"/>
-<xacro:property name="trolley_wheel_friction"      value="0.0"/>
-<xacro:property name="trolley_wheel_radius"        value="0.06"/>
-<!-- a small constant -->
-<xacro:property name="eps"                         value="0.002"/>
+    <xacro:property name="trolley_wheel_mass" value="0.1"/>
+    <xacro:property name="trolley_track_width" value="0.54"/>
+    <xacro:property name="trolley_wheel_friction" value="0.0"/>
+    <xacro:property name="trolley_wheel_radius" value="0.06"/>
+    <!-- a small constant -->
+    <xacro:property name="eps" value="0.002"/>
 
-<xacro:property name="traction_wheel_radius"       value="0.1"/>
-<xacro:property name="traction_wheel_width"        value="0.05"/>
-<xacro:property name="traction_track_width"         value="0.8"/>
+    <xacro:property name="traction_wheel_radius" value="0.1"/>
+    <xacro:property name="traction_wheel_width" value="0.05"/>
+    <xacro:property name="traction_track_width" value="0.8"/>
 
-<xacro:property name="two_d_lidar_update_rate"     value="30"/>
-<xacro:property name="two_d_lidar_sample_size"     value="361"/>
-<xacro:property name="two_d_lidar_min_angle"       value="0"/>
-<xacro:property name="two_d_lidar_max_angle"       value="360"/>
-<xacro:property name="two_d_lidar_min_range"       value="0.55"/>
-<xacro:property name="two_d_lidar_max_range"       value="16"/>
+    <xacro:property name="two_d_lidar_update_rate" value="30"/>
+    <xacro:property name="two_d_lidar_sample_size" value="361"/>
+    <xacro:property name="two_d_lidar_min_angle" value="0"/>
+    <xacro:property name="two_d_lidar_max_angle" value="360"/>
+    <xacro:property name="two_d_lidar_min_range" value="0.55"/>
+    <xacro:property name="two_d_lidar_max_range" value="16"/>
 
-<xacro:property name="camera_baseline"             value="0.06"/>
-<xacro:property name="camera_height"               value="0.10"/>
-<xacro:property name="camera_horizontal_fov"       value="60"/>
+    <xacro:property name="camera_baseline" value="0.06"/>
+    <xacro:property name="camera_height" value="0.10"/>
+    <xacro:property name="camera_horizontal_fov" value="60"/>
 
-<xacro:arg      name="robot_namespace"             default=""/>
-<xacro:arg      name="wheel_odom_topic"            default="odom" />
-<xacro:arg      name="camera_enabled"              default="false" />
-<xacro:arg      name="stereo_camera_enabled"       default="false" />
-<xacro:arg      name="two_d_lidar_enabled"         default="false" />
-<xacro:arg      name="publish_wheel_odom_tf"       default="true" />
-<xacro:arg      name="conveyor_enabled"            default="false"/>
-<xacro:arg      name="ground_truth_frame"          default="map"/>
-<xacro:arg      name="sim_gazebo"                  default="false" />
-<xacro:arg      name="sim_gz"                      default="false" />
-<xacro:arg      name="odometry_source"             default="world" />
+    <xacro:arg name="robot_namespace" default=""/>
+    <xacro:arg name="wheel_odom_topic" default="odom" />
+    <xacro:arg name="camera_enabled" default="false" />
+    <xacro:arg name="stereo_camera_enabled" default="false" />
+    <xacro:arg name="two_d_lidar_enabled" default="false" />
+    <xacro:arg name="publish_wheel_odom_tf" default="true" />
+    <xacro:arg name="conveyor_enabled" default="false"/>
+    <xacro:arg name="ground_truth_frame" default="map"/>
+    <xacro:arg name="sim_gazebo" default="false" />
+    <xacro:arg name="sim_gz" default="false" />
+    <xacro:arg name="odometry_source" default="world" />
 
-<xacro:property name="odometry_source"             value="$(arg odometry_source)"/>
+    <xacro:property name="odometry_source" value="$(arg odometry_source)"/>
 
-<!-- ............................... LOAD MACROS ................................. -->
+    <!-- ............................... LOAD MACROS ................................. -->
 
-<xacro:include filename="$(find bcr_bot)/urdf/materials.xacro"/>
-<xacro:include filename="$(find bcr_bot)/urdf/macros.xacro"/>
+    <xacro:include filename="$(find bcr_bot)/urdf/materials.xacro"/>
+    <xacro:include filename="$(find bcr_bot)/urdf/macros.xacro"/>
 
-<xacro:if value="$(arg sim_gazebo)">
-	<xacro:include filename="$(find bcr_bot)/urdf/gazebo.xacro"/>
-</xacro:if>
+    <xacro:if value="$(arg sim_gazebo)">
+        <xacro:include filename="$(find bcr_bot)/urdf/gazebo.xacro"/>
+    </xacro:if>
 
-<xacro:if value="$(arg sim_gz)">
-	<xacro:include filename="$(find bcr_bot)/urdf/gz.xacro"/>
-</xacro:if>
+    <xacro:if value="$(arg sim_gz)">
+        <xacro:include filename="$(find bcr_bot)/urdf/gz.xacro"/>
+    </xacro:if>
 
-<!-- ................................ BASE LINK .................................. -->
+    <!-- ................................ BASE LINK .................................. -->
 
-<link name="base_link"/>
+    <link name="base_link"/>
 
-<link name="chassis_link">
+    <link name="chassis_link">
 
-	<collision>
-		<origin xyz="0 0 -0.05" rpy="0 0 0" />
-  		<geometry>
-			<box size="${chassis_length} ${chassis_width} ${chassis_height}"/>
-  		</geometry>
-	</collision>
-
-	<visual>
-		<origin xyz="0 0 -0.205" rpy="0 0 0" />
-  		<geometry>
-    		<mesh filename="file://$(find bcr_bot)/meshes/bcr_bot_mesh.dae" scale="1 1 1"/>
-  		</geometry>
-	</visual>
-
-	<inertial>
-		<mass value="${chassis_mass}" />
-		<xacro:box_inertia m="${chassis_mass}" x="${chassis_length}" y="${chassis_width}" z = "${chassis_height}"/>
-	</inertial>
-
-</link>
-
-<joint name="chassis_joint" type="fixed">
-	<parent link="base_link"/>
-	<child link="chassis_link"/>
-	<origin xyz="0.0 0 0" rpy="0 0 0.0" />
-</joint>
-
-<!-- ................................ WHEELS ..................................... -->
-
-<xacro:trolley_wheel cardinality="front" dexterity="left"  origin_x="${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-<xacro:trolley_wheel cardinality="front" dexterity="right" origin_x="${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-
-<xacro:trolley_wheel cardinality="back" dexterity="left"  origin_x="-${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-<xacro:trolley_wheel cardinality="back" dexterity="right" origin_x="-${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
-
-<xacro:traction_wheel cardinality="middle" dexterity="left"  origin_x="0" origin_y="${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
-<xacro:traction_wheel cardinality="middle" dexterity="right" origin_x="0" origin_y="-${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
-
-<!-- ............................. 2D LIDAR ........................................ -->
-
-<xacro:if value="$(arg two_d_lidar_enabled)">
-
-    <link name="two_d_lidar">
         <collision>
-          <origin xyz="0 0 0" rpy="0 0 0" />
-          <geometry>
-           <cylinder length="0.06" radius="0.075"/>
-          </geometry>
+            <origin xyz="0 0 -0.05" rpy="0 0 0" />
+            <geometry>
+                <box size="${chassis_length} ${chassis_width} ${chassis_height}"/>
+            </geometry>
         </collision>
 
         <visual>
-          <origin xyz="0 0 0" rpy="0 0 0" />
-          <geometry>
-           <cylinder length="0.06" radius="0.075"/>
-          </geometry>
-          <material name="aluminium"/>
+            <origin xyz="0 0 -0.205" rpy="0 0 0" />
+            <geometry>
+                <mesh filename="file://$(find bcr_bot)/meshes/bcr_bot_mesh.dae" scale="1 1 1"/>
+            </geometry>
         </visual>
 
         <inertial>
-          <origin xyz="0 0 0" rpy="0 0 0" />
-          <mass value="0.1"/>
-          <xacro:cylinder_inertia m="0.1" r="0.075" h="0.06"/>
+            <mass value="${chassis_mass}" />
+            <xacro:box_inertia m="${chassis_mass}" x="${chassis_length}" y="${chassis_width}" z = "${chassis_height}"/>
         </inertial>
-   </link>
 
-   <joint name="two_d_lidar_joint" type="fixed">
-      <parent link="base_link"/>
-      <child link="two_d_lidar"/>
-      <origin xyz="0.0 0 0.08" rpy="0 0 0" />
+    </link>
+
+    <joint name="chassis_joint" type="fixed">
+        <parent link="base_link"/>
+        <child link="chassis_link"/>
+        <origin xyz="0.0 0 0" rpy="0 0 0.0" />
     </joint>
 
-   <gazebo reference="two_d_lidar">
-       <material>Gazebo/White</material>
-   </gazebo>
+    <!-- ................................ WHEELS ..................................... -->
 
-</xacro:if>
+    <xacro:trolley_wheel cardinality="front" dexterity="left" origin_x="${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
+    <xacro:trolley_wheel cardinality="front" dexterity="right" origin_x="${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
 
-<!-- ............................. IMU ........................................ -->
+    <xacro:trolley_wheel cardinality="back" dexterity="left" origin_x="-${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
+    <xacro:trolley_wheel cardinality="back" dexterity="right" origin_x="-${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
 
-<link name="imu_frame"/>
+    <xacro:traction_wheel cardinality="middle" dexterity="left" origin_x="0" origin_y="${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
+    <xacro:traction_wheel cardinality="middle" dexterity="right" origin_x="0" origin_y="-${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
 
-<joint name="imu_joint" type="fixed">
-    <parent link="base_link"/>
-    <child link="imu_frame"/>
-    <origin xyz="0.0 0.0 0.08" rpy="0.0 0.0 0.0"/>
-</joint>
+    <!-- ............................. 2D LIDAR ........................................ -->
 
-<!-- ............................. CAMERA ........................................ -->
+    <xacro:if value="$(arg two_d_lidar_enabled)">
 
-<xacro:if value="$(arg camera_enabled)">
+        <link name="two_d_lidar">
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <cylinder length="0.06" radius="0.075"/>
+                </geometry>
+            </collision>
 
-	<!-- KINECT CAMERA -->
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <cylinder length="0.06" radius="0.075"/>
+                </geometry>
+                <material name="aluminium"/>
+            </visual>
 
-	<link name="kinect_camera">
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <mass value="0.1"/>
+                <xacro:cylinder_inertia m="0.1" r="0.075" h="0.06"/>
+            </inertial>
+        </link>
 
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-				<geometry>
-					<box size="0.07 0.3 0.09"/>
-				</geometry>
-		</collision>
+        <joint name="two_d_lidar_joint" type="fixed">
+            <parent link="base_link"/>
+            <child link="two_d_lidar"/>
+            <origin xyz="0.0 0 0.08" rpy="0 0 0" />
+        </joint>
 
-		<visual>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-				<geometry>
-					<mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
-				</geometry>
-				<material name="black"/>
-		</visual>
+        <gazebo reference="two_d_lidar">
+            <material>Gazebo/White</material>
+        </gazebo>
 
-		<inertial>
-				<mass value="0.01"/>
-				<xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
-		</inertial>
+    </xacro:if>
 
-	</link>
+    <!-- ............................. IMU ........................................ -->
 
-	<joint name="kinect_camera_joint" type="fixed">
-			<origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
-			<parent link="base_link"/>
-			<child link="kinect_camera"/>
-	</joint>
+    <link name="imu_frame"/>
 
-	<link name="kinect_camera_optical"/>
+    <joint name="imu_joint" type="fixed">
+        <parent link="base_link"/>
+        <child link="imu_frame"/>
+        <origin xyz="0.0 0.0 0.08" rpy="0.0 0.0 0.0"/>
+    </joint>
 
-	<joint name="kinect_camera_optical_joint" type="fixed">
-		<origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
-		<parent link="kinect_camera"/>
-		<child link="kinect_camera_optical"/>
-	</joint>
+    <!-- ............................. CAMERA ........................................ -->
 
-</xacro:if>
+    <xacro:if value="$(arg camera_enabled)">
 
+        <!-- KINECT CAMERA -->
 
+        <link name="kinect_camera">
 
-<!-- .............................STEREO CAMERA ........................................ -->
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="0.07 0.3 0.09"/>
+                </geometry>
+            </collision>
 
-<xacro:if value="$(arg stereo_camera_enabled)">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
+                </geometry>
+                <material name="black"/>
+            </visual>
 
-	<!-- STEREO CAMERA -->
+            <inertial>
+                <mass value="0.01"/>
+                <xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
+            </inertial>
 
-	<link name="stereo_camera">
+        </link>
 
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-				<geometry>
-					<box size="0.07 0.3 0.09"/>
-				</geometry>
-		</collision>
+        <joint name="kinect_camera_joint" type="fixed">
+            <origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
+            <parent link="base_link"/>
+            <child link="kinect_camera"/>
+        </joint>
 
-		<visual>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-				<geometry>
-					<mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
-				</geometry>
-				<material name="black"/>
-		</visual>
+        <link name="kinect_camera_optical"/>
 
-		<inertial>
-				<mass value="0.01"/>
-				<xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
-		</inertial>
+        <joint name="kinect_camera_optical_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+            <parent link="kinect_camera"/>
+            <child link="kinect_camera_optical"/>
+        </joint>
 
-	</link>
+    </xacro:if>
 
-	<joint name="stereo_camera_joint" type="fixed">
-			<origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
-			<parent link="base_link"/>
-			<child link="stereo_camera"/>
-	</joint>
+    <!-- .............................STEREO CAMERA ........................................ -->
 
-	<link name="stereo_camera_optical"/>
+    <xacro:if value="$(arg stereo_camera_enabled)">
 
-	<joint name="stereo_camera_optical_joint" type="fixed">
-		<origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
-		<parent link="stereo_camera"/>
-		<child link="stereo_camera_optical"/>
-	</joint>
+        <!-- STEREO CAMERA -->
 
-</xacro:if>
+        <link name="stereo_camera">
 
-<!-- ............................. ROOF ........................................ -->
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="0.07 0.3 0.09"/>
+                </geometry>
+            </collision>
 
-<link name="roof_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="file://$(find bcr_bot)/meshes/kinect/d415.dae"/>
+                </geometry>
+                <material name="black"/>
+            </visual>
 
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-			<geometry>
-			<box size="${chassis_length} ${chassis_width} 0.015"/>
-			</geometry>
-		</collision>
+            <inertial>
+                <mass value="0.01"/>
+                <xacro:box_inertia m="0.01" x="0.07" y="0.3" z = "0.09"/>
+            </inertial>
 
-		<inertial>
-			<mass value="1"/>
-			<xacro:box_inertia m="1" x="1" y="0.6" z = "0.015"/>
-		</inertial>
-	
-	</link>
+        </link>
 
-	<joint name="roof joint" type="fixed">
-		<parent link="chassis_link"/>
-		<child link="roof_link"/>
-		<origin xyz="0 0 0.16" rpy="0 0 0" />
-	</joint>
+        <joint name="stereo_camera_joint" type="fixed">
+            <origin rpy="0 0 0" xyz="${chassis_length/2} 0 ${chassis_height/7}"/>
+            <parent link="base_link"/>
+            <child link="stereo_camera"/>
+        </joint>
 
-<!-- ............................. CONVEYOR ........................................ -->
+        <link name="stereo_camera_optical"/>
 
-<xacro:if value="$(arg conveyor_enabled)">
+        <joint name="stereo_camera_optical_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+            <parent link="stereo_camera"/>
+            <child link="stereo_camera_optical"/>
+        </joint>
 
-	<link name="conveyor_belt">
+    </xacro:if>
 
-		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-			<geometry>
-			<box size="1 0.6 0.015"/>
-			</geometry>
-		</collision>
+    <!-- ............................. ROOF ........................................ -->
 
-		<visual>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<geometry>
-			<box size="1 0.6 0.015"/>
-			</geometry>
-		</visual>
+    <link name="roof_link">
 
-		<inertial>
-			<mass value="1"/>
-			<xacro:box_inertia m="1" x="1" y="0.6" z = "0.015"/>
-		</inertial>
-	
-	</link>
+        <collision>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+                <box size="${chassis_length} ${chassis_width} 0.015"/>
+            </geometry>
+        </collision>
 
-	<joint name="conveyor_joint" type="fixed">
-		<parent link="base_link"/>
-		<child link="conveyor_belt"/>
-		<origin xyz="0 0 0.25" rpy="0 0 0" />
-	</joint>
+        <inertial>
+            <mass value="1"/>
+            <xacro:box_inertia m="1" x="1" y="0.6" z = "0.015"/>
+        </inertial>
 
-</xacro:if>
-<!-- ............................................................................... -->
+    </link>
+
+    <joint name="roof joint" type="fixed">
+        <parent link="chassis_link"/>
+        <child link="roof_link"/>
+        <origin xyz="0 0 0.16" rpy="0 0 0" />
+    </joint>
+
+    <!-- ............................. CONVEYOR ........................................ -->
+
+    <xacro:if value="$(arg conveyor_enabled)">
+
+        <link name="conveyor_belt">
+
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="1 0.6 0.015"/>
+                </geometry>
+            </collision>
+
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <box size="1 0.6 0.015"/>
+                </geometry>
+            </visual>
+
+            <inertial>
+                <mass value="1"/>
+                <xacro:box_inertia m="1" x="1" y="0.6" z = "0.015"/>
+            </inertial>
+
+        </link>
+
+        <joint name="conveyor_joint" type="fixed">
+            <parent link="base_link"/>
+            <child link="conveyor_belt"/>
+            <origin xyz="0 0 0.25" rpy="0 0 0" />
+        </joint>
+
+    </xacro:if>
+    <!-- ............................................................................... -->
 
 </robot>

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -145,6 +145,79 @@
 	</gazebo>
 </xacro:if>
 
-<!--................................................................................. -->
+<!-- ...........................STEREO CAMERA PLUGIN ................................... -->
 
+<xacro:if value="$(arg stereo_camera_enabled)">
+	<gazebo reference="stereo_camera">
+		<sensor type="multicamera" name="stereo_camera">
+			<update_rate>10.0</update_rate>
+			<always_on>true</always_on>
+			<camera name="left">
+				<pose>0 0 0 0 0 0</pose>
+				<horizontal_fov>1.3962634</horizontal_fov>
+				<image>
+				<width>1024</width>
+				<height>1024</height>
+				<format>R8G8B8</format>
+				</image>
+				<clip>
+				<near>0.3</near>
+				<far>20</far>
+				</clip>
+				<noise>
+				<type>gaussian</type>
+				<mean>0.0</mean>
+				<stddev>0.0</stddev>
+				</noise>
+				<distortion>
+				<k1>0.0</k1>
+				<k2>0.0</k2>
+				<k3>0.0</k3>
+				<p1>0.0</p1>
+				<p2>0.0</p2>
+				<center>0.5 0.5</center>
+				</distortion>
+			</camera>
+
+			<camera name="right">
+				<pose>0 -0.12 0 0 0 0</pose>
+				<horizontal_fov>1.3962634</horizontal_fov>
+				<image>
+				<width>1024</width>
+				<height>1024</height>
+				<format>R8G8B8</format>
+				</image>
+				<clip>
+				<near>0.3</near>
+				<far>20</far>
+				</clip>
+				<noise>
+				<type>gaussian</type>
+				<mean>0.0</mean>
+				<stddev>0.0</stddev>
+				</noise>
+				<distortion>
+				<k1>0.0</k1>
+				<k2>0.0</k2>
+				<k3>0.0</k3>
+				<p1>0.0</p1>
+				<p2>0.0</p2>
+				<center>0.5 0.5</center>
+				</distortion>
+			</camera>
+
+			<plugin name="stereo_camera_controller" filename="libgazebo_ros_camera.so">
+				<ros>
+				<namespace>$(arg robot_namespace)</namespace>
+				<argument>image_raw:=image_raw</argument>
+				<argument>camera_info:=camera_info</argument>
+				</ros>
+				<camera_name>stereo_camera</camera_name>
+				<frame_name>stereo_camera_optical</frame_name>
+				<hack_baseline>0.12</hack_baseline>
+			</plugin>
+			
+		</sensor>
+	</gazebo>
+</xacro:if>
 </robot>

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -1,223 +1,223 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-<gazebo>
-	<static>false</static>
-</gazebo>
+    <gazebo>
+        <static>false</static>
+    </gazebo>
 
-<!-- .....................MULTI WHEEL DIFF DRIVE ................................... -->
+    <!-- .....................MULTI WHEEL DIFF DRIVE ................................... -->
 
-<gazebo>
-	<plugin name="diff_drive" filename="libgazebo_ros_diff_drive.so">
-		<ros>
-			<namespace>$(arg robot_namespace)</namespace>
-			<remapping>cmd_vel:=cmd_vel</remapping>
-			<remapping>odom:=odom</remapping>
-		</ros>
-		<legacy_mode>false</legacy_mode>
-		<update_rate>50.0</update_rate>
-		<left_joint>middle_left_wheel_joint</left_joint>
-		<right_joint>middle_right_wheel_joint</right_joint>
-		<wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
-		<wheel_diameter>${2*traction_wheel_radius+0.01}</wheel_diameter>
-		<robot_base_frame>base_link</robot_base_frame>
-		<max_wheel_torque>${traction_max_wheel_torque}</max_wheel_torque>
-		<command_topic>cmd_vel</command_topic>
-		<odometry_topic>$(arg wheel_odom_topic)</odometry_topic>
-		<odometry_frame>odom</odometry_frame>
-		<publish_odom_tf>$(arg publish_wheel_odom_tf)</publish_odom_tf>
-		<publish_wheel_tf>true</publish_wheel_tf>
-		<publish_odom>true</publish_odom>
-		<max_wheel_acceleration>5.0</max_wheel_acceleration>
-		<!-- Odometry source, 0 for ENCODER, 1 for WORLD, defaults to WORLD -->
-		<xacro:if value="${odometry_source == 'world'}">
-			<odometry_source>1</odometry_source>
-		</xacro:if>
-		<xacro:if value="${odometry_source == 'encoder'}">
-			<odometry_source>0</odometry_source>
-		</xacro:if>
-	</plugin>
-</gazebo>
+    <gazebo>
+        <plugin name="diff_drive" filename="libgazebo_ros_diff_drive.so">
+            <ros>
+                <namespace>$(arg robot_namespace)</namespace>
+                <remapping>cmd_vel:=cmd_vel</remapping>
+                <remapping>odom:=odom</remapping>
+            </ros>
+            <legacy_mode>false</legacy_mode>
+            <update_rate>50.0</update_rate>
+            <left_joint>middle_left_wheel_joint</left_joint>
+            <right_joint>middle_right_wheel_joint</right_joint>
+            <wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
+            <wheel_diameter>${2*traction_wheel_radius+0.01}</wheel_diameter>
+            <robot_base_frame>base_link</robot_base_frame>
+            <max_wheel_torque>${traction_max_wheel_torque}</max_wheel_torque>
+            <command_topic>cmd_vel</command_topic>
+            <odometry_topic>$(arg wheel_odom_topic)</odometry_topic>
+            <odometry_frame>odom</odometry_frame>
+            <publish_odom_tf>$(arg publish_wheel_odom_tf)</publish_odom_tf>
+            <publish_wheel_tf>true</publish_wheel_tf>
+            <publish_odom>true</publish_odom>
+            <max_wheel_acceleration>5.0</max_wheel_acceleration>
+            <!-- Odometry source, 0 for ENCODER, 1 for WORLD, defaults to WORLD -->
+            <xacro:if value="${odometry_source == 'world'}">
+                <odometry_source>1</odometry_source>
+            </xacro:if>
+            <xacro:if value="${odometry_source == 'encoder'}">
+                <odometry_source>0</odometry_source>
+            </xacro:if>
+        </plugin>
+    </gazebo>
 
-<!--............................... IMU PLUGIN ..................................... -->
+    <!--............................... IMU PLUGIN ..................................... -->
 
-<gazebo reference="imu_frame">
-		<sensor name="imu" type="imu">
-			<always_on>true</always_on>
-			<update_rate>5</update_rate>
-			<plugin name="imu_plugin" filename="libgazebo_ros_imu_sensor.so">
-				<ros>
-					<namespace>$(arg robot_namespace)</namespace>
-					<remapping>~/out:=imu</remapping>
-				</ros>
-			</plugin>
-		</sensor>
-</gazebo>
+    <gazebo reference="imu_frame">
+        <sensor name="imu" type="imu">
+            <always_on>true</always_on>
+            <update_rate>5</update_rate>
+            <plugin name="imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+                <ros>
+                    <namespace>$(arg robot_namespace)</namespace>
+                    <remapping>~/out:=imu</remapping>
+                </ros>
+            </plugin>
+        </sensor>
+    </gazebo>
 
-<!--............................... Ground truth PLUGIN .............................-->
+    <!--............................... Ground truth PLUGIN .............................-->
 
 
-<gazebo>
-	<plugin name="p3d_base_controller" filename="libgazebo_ros_p3d.so">
-		<ros>
-			<!-- Add namespace and remap the default topic -->
-			<namespace>$(arg robot_namespace)</namespace>
-			<remapping>odom:=p3d_ground_truth</remapping>
-		</ros>
-		<always_on>true</always_on>
-		<update_rate>30.0</update_rate>
-		<body_name>base_link</body_name>
-		<gaussian_noise>0.00</gaussian_noise>
-		<frame_name>$(arg ground_truth_frame)</frame_name>
-	</plugin>
-</gazebo>
+    <gazebo>
+        <plugin name="p3d_base_controller" filename="libgazebo_ros_p3d.so">
+            <ros>
+                <!-- Add namespace and remap the default topic -->
+                <namespace>$(arg robot_namespace)</namespace>
+                <remapping>odom:=p3d_ground_truth</remapping>
+            </ros>
+            <always_on>true</always_on>
+            <update_rate>30.0</update_rate>
+            <body_name>base_link</body_name>
+            <gaussian_noise>0.00</gaussian_noise>
+            <frame_name>$(arg ground_truth_frame)</frame_name>
+        </plugin>
+    </gazebo>
 
-<!-- ........................... 2D LIDAR PLUGIN ................................... -->
+    <!-- ........................... 2D LIDAR PLUGIN ................................... -->
 
-<xacro:if value="$(arg two_d_lidar_enabled)">
+    <xacro:if value="$(arg two_d_lidar_enabled)">
 
-	<gazebo reference="two_d_lidar">
-		<gravity>true</gravity>
-		<sensor type="ray" name="two_d_lidar">
-			<pose>0 0 0 0 0 0</pose>
-			<visualize>false</visualize>
-			<update_rate>${two_d_lidar_update_rate}</update_rate>
-			<ray>
-				<scan>
-					<horizontal>
-						<samples>${two_d_lidar_sample_size}</samples>
-						<resolution>1</resolution>
-						<min_angle>${radians(two_d_lidar_min_angle)}</min_angle>
-						<max_angle>${radians(two_d_lidar_max_angle)}</max_angle>
-					</horizontal>
-				</scan>
-				<range>
-					<min>${two_d_lidar_min_range}</min>
-					<max>${two_d_lidar_max_range}</max>
-					<resolution>0.01</resolution>
-				</range>
-				<noise>
-					<type>gaussian</type>
-					<mean>0.0</mean>
-					<stddev>0.0</stddev>
-				</noise>
-			</ray>
-			<plugin name="gazebo_ros_laser" filename="libgazebo_ros_ray_sensor.so">
-				<ros>
-					<remapping>~/out:=$(arg robot_namespace)/scan</remapping>
-				</ros>
-				<output_type>sensor_msgs/LaserScan</output_type>
-				<frame_name>two_d_lidar</frame_name>
-			</plugin>
-		</sensor>
-	</gazebo>
-</xacro:if>
+        <gazebo reference="two_d_lidar">
+            <gravity>true</gravity>
+            <sensor type="ray" name="two_d_lidar">
+                <pose>0 0 0 0 0 0</pose>
+                <visualize>false</visualize>
+                <update_rate>${two_d_lidar_update_rate}</update_rate>
+                <ray>
+                    <scan>
+                        <horizontal>
+                            <samples>${two_d_lidar_sample_size}</samples>
+                            <resolution>1</resolution>
+                            <min_angle>${radians(two_d_lidar_min_angle)}</min_angle>
+                            <max_angle>${radians(two_d_lidar_max_angle)}</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>${two_d_lidar_min_range}</min>
+                        <max>${two_d_lidar_max_range}</max>
+                        <resolution>0.01</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.0</stddev>
+                    </noise>
+                </ray>
+                <plugin name="gazebo_ros_laser" filename="libgazebo_ros_ray_sensor.so">
+                    <ros>
+                        <remapping>~/out:=$(arg robot_namespace)/scan</remapping>
+                    </ros>
+                    <output_type>sensor_msgs/LaserScan</output_type>
+                    <frame_name>two_d_lidar</frame_name>
+                </plugin>
+            </sensor>
+        </gazebo>
+    </xacro:if>
 
-<!-- ........................... CAMERA PLUGIN ................................... -->
+    <!-- ........................... CAMERA PLUGIN ................................... -->
 
-<xacro:if value="$(arg camera_enabled)">
-	 <gazebo reference="kinect_camera">
-		<sensor name="kinect_camera" type="depth">
-			<pose> 0 0 0 0 0 0 </pose>
-			<visualize>true</visualize>
-			<update_rate>30</update_rate>
-			<camera>
-				<horizontal_fov>1.089</horizontal_fov>
-				<image>
-					<format>R8G8B8</format>
-					<width>640</width>
-					<height>480</height>
-				</image>
-				<clip>
-					<near>0.05</near>
-					<far>8.0</far>
-				</clip>
-			</camera>
-			<plugin name="camera_controller" filename="libgazebo_ros_camera.so">
-				<ros>
-					<namespace>$(arg robot_namespace)</namespace>
-				</ros>
-				<frame_name>kinect_camera_optical</frame_name>
-				<min_depth>0.1</min_depth>
-				<max_depth>100</max_depth>
-			</plugin>
-		</sensor>
-	</gazebo>
-</xacro:if>
+    <xacro:if value="$(arg camera_enabled)">
+        <gazebo reference="kinect_camera">
+            <sensor name="kinect_camera" type="depth">
+                <pose> 0 0 0 0 0 0 </pose>
+                <visualize>true</visualize>
+                <update_rate>30</update_rate>
+                <camera>
+                    <horizontal_fov>1.089</horizontal_fov>
+                    <image>
+                        <format>R8G8B8</format>
+                        <width>640</width>
+                        <height>480</height>
+                    </image>
+                    <clip>
+                        <near>0.05</near>
+                        <far>8.0</far>
+                    </clip>
+                </camera>
+                <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+                    <ros>
+                        <namespace>$(arg robot_namespace)</namespace>
+                    </ros>
+                    <frame_name>kinect_camera_optical</frame_name>
+                    <min_depth>0.1</min_depth>
+                    <max_depth>100</max_depth>
+                </plugin>
+            </sensor>
+        </gazebo>
+    </xacro:if>
 
-<!-- ...........................STEREO CAMERA PLUGIN ................................... -->
+    <!-- ...........................STEREO CAMERA PLUGIN ................................... -->
 
-<xacro:if value="$(arg stereo_camera_enabled)">
-	<gazebo reference="stereo_camera">
-		<sensor type="multicamera" name="stereo_camera">
-			<update_rate>10.0</update_rate>
-			<always_on>true</always_on>
-			<camera name="left">
-				<pose>0 0 0 0 0 0</pose>
-				<horizontal_fov>1.3962634</horizontal_fov>
-				<image>
-				<width>1024</width>
-				<height>1024</height>
-				<format>R8G8B8</format>
-				</image>
-				<clip>
-				<near>0.3</near>
-				<far>20</far>
-				</clip>
-				<noise>
-				<type>gaussian</type>
-				<mean>0.0</mean>
-				<stddev>0.0</stddev>
-				</noise>
-				<distortion>
-				<k1>0.0</k1>
-				<k2>0.0</k2>
-				<k3>0.0</k3>
-				<p1>0.0</p1>
-				<p2>0.0</p2>
-				<center>0.5 0.5</center>
-				</distortion>
-			</camera>
+    <xacro:if value="$(arg stereo_camera_enabled)">
+        <gazebo reference="stereo_camera">
+            <sensor type="multicamera" name="stereo_camera">
+                <update_rate>10.0</update_rate>
+                <always_on>true</always_on>
+                <camera name="left">
+                    <pose>0 0 0 0 0 0</pose>
+                    <horizontal_fov>1.3962634</horizontal_fov>
+                    <image>
+                        <width>1024</width>
+                        <height>1024</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.3</near>
+                        <far>20</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.0</stddev>
+                    </noise>
+                    <distortion>
+                        <k1>0.0</k1>
+                        <k2>0.0</k2>
+                        <k3>0.0</k3>
+                        <p1>0.0</p1>
+                        <p2>0.0</p2>
+                        <center>0.5 0.5</center>
+                    </distortion>
+                </camera>
 
-			<camera name="right">
-				<pose>0 -0.12 0 0 0 0</pose>
-				<horizontal_fov>1.3962634</horizontal_fov>
-				<image>
-				<width>1024</width>
-				<height>1024</height>
-				<format>R8G8B8</format>
-				</image>
-				<clip>
-				<near>0.3</near>
-				<far>20</far>
-				</clip>
-				<noise>
-				<type>gaussian</type>
-				<mean>0.0</mean>
-				<stddev>0.0</stddev>
-				</noise>
-				<distortion>
-				<k1>0.0</k1>
-				<k2>0.0</k2>
-				<k3>0.0</k3>
-				<p1>0.0</p1>
-				<p2>0.0</p2>
-				<center>0.5 0.5</center>
-				</distortion>
-			</camera>
+                <camera name="right">
+                    <pose>0 -0.12 0 0 0 0</pose>
+                    <horizontal_fov>1.3962634</horizontal_fov>
+                    <image>
+                        <width>1024</width>
+                        <height>1024</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.3</near>
+                        <far>20</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.0</stddev>
+                    </noise>
+                    <distortion>
+                        <k1>0.0</k1>
+                        <k2>0.0</k2>0
+                        <k3>0.0</k3>
+                        <p1>0.0</p1>
+                        <p2>0.0</p2>
+                        <center>0.5 0.5</center>
+                    </distortion>
+                </camera>
 
-			<plugin name="stereo_camera_controller" filename="libgazebo_ros_camera.so">
-				<ros>
-				<namespace>$(arg robot_namespace)</namespace>
-				<argument>image_raw:=image_raw</argument>
-				<argument>camera_info:=camera_info</argument>
-				</ros>
-				<camera_name>stereo_camera</camera_name>
-				<frame_name>stereo_camera_optical</frame_name>
-				<hack_baseline>0.12</hack_baseline>
-			</plugin>
-			
-		</sensor>
-	</gazebo>
-</xacro:if>
+                <plugin name="stereo_camera_controller" filename="libgazebo_ros_camera.so">
+                    <ros>
+                        <namespace>$(arg robot_namespace)</namespace>
+                        <argument>image_raw:=image_raw</argument>
+                        <argument>camera_info:=camera_info</argument>
+                    </ros>
+                    <camera_name>stereo_camera</camera_name>
+                    <frame_name>stereo_camera_optical</frame_name>
+                    <hack_baseline>0.12</hack_baseline>
+                </plugin>
+
+            </sensor>
+        </gazebo>
+    </xacro:if>
 </robot>

--- a/urdf/gz.xacro
+++ b/urdf/gz.xacro
@@ -4,103 +4,145 @@
 <!-- ........................... SENSOR PLUGIN ................................... -->
 
 <gazebo>
-    <plugin filename="ignition-gazebo-sensors-system" name="ignition::gazebo::systems::Sensors">
-        <render_engine>ogre2</render_engine>
-    </plugin>
+	<plugin filename="ignition-gazebo-sensors-system" name="ignition::gazebo::systems::Sensors">
+		<render_engine>ogre2</render_engine>
+	</plugin>
 
-    <plugin filename="ignition-gazebo-imu-system"
-        name="ignition::gazebo::systems::Imu">
-    </plugin>
+	<plugin filename="ignition-gazebo-imu-system"
+		name="ignition::gazebo::systems::Imu">
+	</plugin>
 
-    <plugin filename="ignition-gazebo-joint-state-publisher-system" 
-        name="ignition::gazebo::systems::JointStatePublisher">
-    </plugin>
+	<plugin filename="ignition-gazebo-joint-state-publisher-system" 
+		name="ignition::gazebo::systems::JointStatePublisher">
+	</plugin>
 
 <!-- ........................... DIFFERENTIAL DRIVE PLUGIN ................................... -->
 
-    <plugin filename="ignition-gazebo-diff-drive-system" name="ignition::gazebo::systems::DiffDrive">
-        <left_joint>middle_left_wheel_joint</left_joint>
-        <right_joint>middle_right_wheel_joint</right_joint>
-        <wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
-        <wheel_radius>${traction_wheel_radius+0.01}</wheel_radius>
-        <odom_publish_frequency>30</odom_publish_frequency>
-        <topic>/cmd_vel</topic>
-        <odom_topic>$(arg wheel_odom_topic)</odom_topic>
-        <tf_topic>/tf</tf_topic>
-        <frame_id>odom</frame_id>
-        <child_frame_id>base_link</child_frame_id>
-    </plugin>
+	<plugin filename="ignition-gazebo-diff-drive-system" name="ignition::gazebo::systems::DiffDrive">
+		<left_joint>middle_left_wheel_joint</left_joint>
+		<right_joint>middle_right_wheel_joint</right_joint>
+		<wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
+		<wheel_radius>${traction_wheel_radius+0.01}</wheel_radius>
+		<odom_publish_frequency>30</odom_publish_frequency>
+		<topic>/cmd_vel</topic>
+		<odom_topic>$(arg wheel_odom_topic)</odom_topic>
+		<tf_topic>/tf</tf_topic>
+		<frame_id>odom</frame_id>
+		<child_frame_id>base_link</child_frame_id>
+	</plugin>
 </gazebo>
 
 <!-- ........................... 2D LIDAR config ................................... -->
 
 <xacro:if value="$(arg two_d_lidar_enabled)">
-    <gazebo reference="two_d_lidar">
-        <sensor name='gpu_lidar' type='gpu_lidar'>
-            <topic>scan</topic>
-            <update_rate>${two_d_lidar_update_rate}</update_rate>
-            <ignition_frame_id>two_d_lidar</ignition_frame_id>
-            <lidar>
-                <scan>
-                    <horizontal>
-                        <samples>${two_d_lidar_sample_size}</samples>
-                        <resolution>1</resolution>
-                        <min_angle>${radians(two_d_lidar_min_angle)}</min_angle>
-                        <max_angle>${radians(two_d_lidar_max_angle)}</max_angle>
-                    </horizontal>
-                </scan>
-                <range>
-                    <min>${two_d_lidar_min_range}</min>
-                    <max>${two_d_lidar_max_range}</max>
-                    <resolution>0.01</resolution>
-                </range>
-                <noise>
-                    <type>gaussian</type>
-                    <mean>0.0</mean>
-                    <stddev>0.001</stddev>
-                </noise>
-            </lidar>
-            <alwaysOn>1</alwaysOn>
-            <visualize>true</visualize>
-        </sensor>
-    </gazebo>
+	<gazebo reference="two_d_lidar">
+		<sensor name='gpu_lidar' type='gpu_lidar'>
+			<topic>scan</topic>
+			<update_rate>${two_d_lidar_update_rate}</update_rate>
+			<ignition_frame_id>two_d_lidar</ignition_frame_id>
+			<lidar>
+				<scan>
+					<horizontal>
+						<samples>${two_d_lidar_sample_size}</samples>
+						<resolution>1</resolution>
+						<min_angle>${radians(two_d_lidar_min_angle)}</min_angle>
+						<max_angle>${radians(two_d_lidar_max_angle)}</max_angle>
+					</horizontal>
+				</scan>
+				<range>
+					<min>${two_d_lidar_min_range}</min>
+					<max>${two_d_lidar_max_range}</max>
+					<resolution>0.01</resolution>
+				</range>
+				<noise>
+					<type>gaussian</type>
+					<mean>0.0</mean>
+					<stddev>0.001</stddev>
+				</noise>
+			</lidar>
+			<alwaysOn>1</alwaysOn>
+			<visualize>true</visualize>
+		</sensor>
+	</gazebo>
 </xacro:if>
 
 <!-- ........................... CAMERA config ................................... -->
 
 <xacro:if value="$(arg camera_enabled)">
-    <gazebo reference="kinect_camera">
-        <sensor type="depth_camera" name="kinect_camera">
-            <update_rate>30.0</update_rate>
-            <topic>kinect_camera</topic>
-            <ignition_frame_id>kinect_camera</ignition_frame_id>
-            <camera_info_topic>camera_info</camera_info_topic>
-            <camera>
-                <horizontal_fov>${radians(camera_horizontal_fov)}</horizontal_fov>
-                <image>
-                    <width>640</width>
-                    <height>480</height>
-                    <format>R8G8B8</format>
-                </image>
-                <clip>
-                    <near>0.05</near>
-                    <far>8.0</far>
-                </clip>
-            </camera>
-        </sensor>
-    </gazebo>
+	<gazebo reference="kinect_camera">
+		<sensor type="depth_camera" name="kinect_camera">
+			<update_rate>30.0</update_rate>
+			<topic>kinect_camera</topic>
+			<ignition_frame_id>kinect_camera</ignition_frame_id>
+			<camera_info_topic>kinect_camera/camera_info</camera_info_topic>
+			<camera>
+				<horizontal_fov>${radians(camera_horizontal_fov)}</horizontal_fov>
+				<image>
+					<width>640</width>
+					<height>480</height>
+					<format>R8G8B8</format>
+				</image>
+				<clip>
+					<near>0.05</near>
+					<far>8.0</far>
+				</clip>
+			</camera>
+		</sensor>
+	</gazebo>
 </xacro:if>
 
 <!-- ........................... IMU config ................................... -->
 
 <gazebo reference="imu_frame">
-    <sensor name="imu_sensor" type="imu">
-        <always_on>1</always_on>
-        <update_rate>1</update_rate>
-        <ignition_frame_id>imu_frame</ignition_frame_id>
-        <visualize>true</visualize>
-        <topic>imu</topic>
-    </sensor>
+	<sensor name="imu_sensor" type="imu">
+		<always_on>1</always_on>
+		<update_rate>1</update_rate>
+		<ignition_frame_id>imu_frame</ignition_frame_id>
+		<visualize>true</visualize>
+		<topic>imu</topic>
+	</sensor>
 </gazebo> 
 
+<!-- ........................... Stereo camera ................................... -->
+<xacro:if value="$(arg stereo_camera_enabled)">
+	<gazebo reference="stereo_camera">
+		<sensor type="camera" name="right">
+			<update_rate>10.0</update_rate>
+			<always_on>true</always_on>
+			<ignition_frame_id>stereo_camera_optical</ignition_frame_id>
+			<pose>0 -0.12 0 0 0 0</pose>
+			<topic>stereo_camera/right/image_raw</topic>
+			<camera_info_topic>stereo_camera/right/camera_info</camera_info_topic>
+			<horizontal_fov>1.3962634</horizontal_fov>
+			<image>
+				<width>1024</width>
+				<height>1024</height>
+				<format>R8G8B8</format>
+			</image>
+			<clip>
+				<near>0.3</near>
+				<far>20</far>
+			</clip>
+		</sensor>
+
+		<sensor type="camera" name="left">
+			<topic>stereo_camera/left/image_raw</topic>
+			<update_rate>10.0</update_rate>
+			<always_on>true</always_on>
+			<ignition_frame_id>stereo_camera_optical</ignition_frame_id>
+			<camera_info_topic>stereo_camera/left/camera_info</camera_info_topic>
+			<pose>0 0 0 0 0 0</pose>
+			<horizontal_fov>1.3962634</horizontal_fov>
+			<image>
+				<width>1024</width>
+				<height>1024</height>
+				<format>R8G8B8</format>
+			</image>
+			<clip>
+				<near>0.3</near>
+				<far>20</far>
+			</clip>
+		</sensor>
+	</gazebo>
+</xacro:if>
 </robot>

--- a/urdf/gz.xacro
+++ b/urdf/gz.xacro
@@ -1,148 +1,146 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-<!-- ........................... SENSOR PLUGIN ................................... -->
+    <!-- ........................... SENSOR PLUGIN ................................... -->
 
-<gazebo>
-	<plugin filename="ignition-gazebo-sensors-system" name="ignition::gazebo::systems::Sensors">
-		<render_engine>ogre2</render_engine>
-	</plugin>
+    <gazebo>
+        <plugin filename="ignition-gazebo-sensors-system" name="ignition::gazebo::systems::Sensors">
+            <render_engine>ogre2</render_engine>
+        </plugin>
 
-	<plugin filename="ignition-gazebo-imu-system"
-		name="ignition::gazebo::systems::Imu">
-	</plugin>
+        <plugin filename="ignition-gazebo-imu-system" name="ignition::gazebo::systems::Imu">
+        </plugin>
 
-	<plugin filename="ignition-gazebo-joint-state-publisher-system" 
-		name="ignition::gazebo::systems::JointStatePublisher">
-	</plugin>
+        <plugin filename="ignition-gazebo-joint-state-publisher-system" name="ignition::gazebo::systems::JointStatePublisher">
+        </plugin>
 
-<!-- ........................... DIFFERENTIAL DRIVE PLUGIN ................................... -->
+        <!-- ........................... DIFFERENTIAL DRIVE PLUGIN ................................... -->
 
-	<plugin filename="ignition-gazebo-diff-drive-system" name="ignition::gazebo::systems::DiffDrive">
-		<left_joint>middle_left_wheel_joint</left_joint>
-		<right_joint>middle_right_wheel_joint</right_joint>
-		<wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
-		<wheel_radius>${traction_wheel_radius+0.01}</wheel_radius>
-		<odom_publish_frequency>30</odom_publish_frequency>
-		<topic>/cmd_vel</topic>
-		<odom_topic>$(arg wheel_odom_topic)</odom_topic>
-		<tf_topic>/tf</tf_topic>
-		<frame_id>odom</frame_id>
-		<child_frame_id>base_link</child_frame_id>
-	</plugin>
-</gazebo>
+        <plugin filename="ignition-gazebo-diff-drive-system" name="ignition::gazebo::systems::DiffDrive">
+            <left_joint>middle_left_wheel_joint</left_joint>
+            <right_joint>middle_right_wheel_joint</right_joint>
+            <wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
+            <wheel_radius>${traction_wheel_radius+0.01}</wheel_radius>
+            <odom_publish_frequency>30</odom_publish_frequency>
+            <topic>/cmd_vel</topic>
+            <odom_topic>$(arg wheel_odom_topic)</odom_topic>
+            <tf_topic>/tf</tf_topic>
+            <frame_id>odom</frame_id>
+            <child_frame_id>base_link</child_frame_id>
+        </plugin>
+    </gazebo>
 
-<!-- ........................... 2D LIDAR config ................................... -->
+    <!-- ........................... 2D LIDAR config ................................... -->
 
-<xacro:if value="$(arg two_d_lidar_enabled)">
-	<gazebo reference="two_d_lidar">
-		<sensor name='gpu_lidar' type='gpu_lidar'>
-			<topic>scan</topic>
-			<update_rate>${two_d_lidar_update_rate}</update_rate>
-			<ignition_frame_id>two_d_lidar</ignition_frame_id>
-			<lidar>
-				<scan>
-					<horizontal>
-						<samples>${two_d_lidar_sample_size}</samples>
-						<resolution>1</resolution>
-						<min_angle>${radians(two_d_lidar_min_angle)}</min_angle>
-						<max_angle>${radians(two_d_lidar_max_angle)}</max_angle>
-					</horizontal>
-				</scan>
-				<range>
-					<min>${two_d_lidar_min_range}</min>
-					<max>${two_d_lidar_max_range}</max>
-					<resolution>0.01</resolution>
-				</range>
-				<noise>
-					<type>gaussian</type>
-					<mean>0.0</mean>
-					<stddev>0.001</stddev>
-				</noise>
-			</lidar>
-			<alwaysOn>1</alwaysOn>
-			<visualize>true</visualize>
-		</sensor>
-	</gazebo>
-</xacro:if>
+    <xacro:if value="$(arg two_d_lidar_enabled)">
+        <gazebo reference="two_d_lidar">
+            <sensor name='gpu_lidar' type='gpu_lidar'>
+                <topic>scan</topic>
+                <update_rate>${two_d_lidar_update_rate}</update_rate>
+                <ignition_frame_id>two_d_lidar</ignition_frame_id>
+                <lidar>
+                    <scan>
+                        <horizontal>
+                            <samples>${two_d_lidar_sample_size}</samples>
+                            <resolution>1</resolution>
+                            <min_angle>${radians(two_d_lidar_min_angle)}</min_angle>
+                            <max_angle>${radians(two_d_lidar_max_angle)}</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>${two_d_lidar_min_range}</min>
+                        <max>${two_d_lidar_max_range}</max>
+                        <resolution>0.01</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.001</stddev>
+                    </noise>
+                </lidar>
+                <alwaysOn>1</alwaysOn>
+                <visualize>true</visualize>
+            </sensor>
+        </gazebo>
+    </xacro:if>
 
-<!-- ........................... CAMERA config ................................... -->
+    <!-- ........................... CAMERA config ................................... -->
 
-<xacro:if value="$(arg camera_enabled)">
-	<gazebo reference="kinect_camera">
-		<sensor type="depth_camera" name="kinect_camera">
-			<update_rate>30.0</update_rate>
-			<topic>kinect_camera</topic>
-			<ignition_frame_id>kinect_camera</ignition_frame_id>
-			<camera_info_topic>kinect_camera/camera_info</camera_info_topic>
-			<camera>
-				<horizontal_fov>${radians(camera_horizontal_fov)}</horizontal_fov>
-				<image>
-					<width>640</width>
-					<height>480</height>
-					<format>R8G8B8</format>
-				</image>
-				<clip>
-					<near>0.05</near>
-					<far>8.0</far>
-				</clip>
-			</camera>
-		</sensor>
-	</gazebo>
-</xacro:if>
+    <xacro:if value="$(arg camera_enabled)">
+        <gazebo reference="kinect_camera">
+            <sensor type="depth_camera" name="kinect_camera">
+                <update_rate>30.0</update_rate>
+                <topic>kinect_camera</topic>
+                <ignition_frame_id>kinect_camera</ignition_frame_id>
+                <camera_info_topic>kinect_camera/camera_info</camera_info_topic>
+                <camera>
+                    <horizontal_fov>${radians(camera_horizontal_fov)}</horizontal_fov>
+                    <image>
+                        <width>640</width>
+                        <height>480</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.05</near>
+                        <far>8.0</far>
+                    </clip>
+                </camera>
+            </sensor>
+        </gazebo>
+    </xacro:if>
 
-<!-- ........................... IMU config ................................... -->
+    <!-- ........................... IMU config ................................... -->
 
-<gazebo reference="imu_frame">
-	<sensor name="imu_sensor" type="imu">
-		<always_on>1</always_on>
-		<update_rate>1</update_rate>
-		<ignition_frame_id>imu_frame</ignition_frame_id>
-		<visualize>true</visualize>
-		<topic>imu</topic>
-	</sensor>
-</gazebo> 
+    <gazebo reference="imu_frame">
+        <sensor name="imu_sensor" type="imu">
+            <always_on>1</always_on>
+            <update_rate>1</update_rate>
+            <ignition_frame_id>imu_frame</ignition_frame_id>
+            <visualize>true</visualize>
+            <topic>imu</topic>
+        </sensor>
+    </gazebo>
 
-<!-- ........................... Stereo camera ................................... -->
-<xacro:if value="$(arg stereo_camera_enabled)">
-	<gazebo reference="stereo_camera">
-		<sensor type="camera" name="right">
-			<update_rate>10.0</update_rate>
-			<always_on>true</always_on>
-			<ignition_frame_id>stereo_camera_optical</ignition_frame_id>
-			<pose>0 -0.12 0 0 0 0</pose>
-			<topic>stereo_camera/right/image_raw</topic>
-			<camera_info_topic>stereo_camera/right/camera_info</camera_info_topic>
-			<horizontal_fov>1.3962634</horizontal_fov>
-			<image>
-				<width>1024</width>
-				<height>1024</height>
-				<format>R8G8B8</format>
-			</image>
-			<clip>
-				<near>0.3</near>
-				<far>20</far>
-			</clip>
-		</sensor>
+    <!-- ........................... Stereo camera ................................... -->
+    <xacro:if value="$(arg stereo_camera_enabled)">
+        <gazebo reference="stereo_camera">
+            <sensor type="camera" name="right">
+                <update_rate>10.0</update_rate>
+                <always_on>true</always_on>
+                <ignition_frame_id>stereo_camera_optical</ignition_frame_id>
+                <pose>0 -0.12 0 0 0 0</pose>
+                <topic>stereo_camera/right/image_raw</topic>
+                <camera_info_topic>stereo_camera/right/camera_info</camera_info_topic>
+                <horizontal_fov>1.3962634</horizontal_fov>
+                <image>
+                    <width>1024</width>
+                    <height>1024</height>
+                    <format>R8G8B8</format>
+                </image>
+                <clip>
+                    <near>0.3</near>
+                    <far>20</far>
+                </clip>
+            </sensor>
 
-		<sensor type="camera" name="left">
-			<topic>stereo_camera/left/image_raw</topic>
-			<update_rate>10.0</update_rate>
-			<always_on>true</always_on>
-			<ignition_frame_id>stereo_camera_optical</ignition_frame_id>
-			<camera_info_topic>stereo_camera/left/camera_info</camera_info_topic>
-			<pose>0 0 0 0 0 0</pose>
-			<horizontal_fov>1.3962634</horizontal_fov>
-			<image>
-				<width>1024</width>
-				<height>1024</height>
-				<format>R8G8B8</format>
-			</image>
-			<clip>
-				<near>0.3</near>
-				<far>20</far>
-			</clip>
-		</sensor>
-	</gazebo>
-</xacro:if>
+            <sensor type="camera" name="left">
+                <topic>stereo_camera/left/image_raw</topic>
+                <update_rate>10.0</update_rate>
+                <always_on>true</always_on>
+                <ignition_frame_id>stereo_camera_optical</ignition_frame_id>
+                <camera_info_topic>stereo_camera/left/camera_info</camera_info_topic>
+                <pose>0 0 0 0 0 0</pose>
+                <horizontal_fov>1.3962634</horizontal_fov>
+                <image>
+                    <width>1024</width>
+                    <height>1024</height>
+                    <format>R8G8B8</format>
+                </image>
+                <clip>
+                    <near>0.3</near>
+                    <far>20</far>
+                </clip>
+            </sensor>
+        </gazebo>
+    </xacro:if>
 </robot>

--- a/urdf/macros.xacro
+++ b/urdf/macros.xacro
@@ -1,90 +1,80 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-<!--................................ INERTIA MATRICES .............................. -->
+    <!--................................ INERTIA MATRICES .............................. -->
 
-<xacro:macro name="cylinder_inertia" params="m r h">
-	<inertia ixx="${m * (3 * r * r + h * h) / 12}" ixy="0" ixz="0"
-		iyy="${m * (3 * r * r + h * h) / 12}" iyz="0"
-		izz="${m * r * r / 2}"
-	/>
-</xacro:macro>
+    <xacro:macro name="cylinder_inertia" params="m r h">
+        <inertia ixx="${m * (3 * r * r + h * h) / 12}" ixy="0" ixz="0" iyy="${m * (3 * r * r + h * h) / 12}" iyz="0" izz="${m * r * r / 2}" />
+    </xacro:macro>
 
-<xacro:macro name="box_inertia" params="m x y z">
-	<inertia ixx="${m * (y * y + z * z) / 12}" ixy="0" ixz="0"
-		iyy="${m * (x * x + z * z) / 12}" iyz="0"
-		izz="${m * (y * y + x * x) / 12}"
-	/>
-</xacro:macro>
+    <xacro:macro name="box_inertia" params="m x y z">
+        <inertia ixx="${m * (y * y + z * z) / 12}" ixy="0" ixz="0" iyy="${m * (x * x + z * z) / 12}" iyz="0" izz="${m * (y * y + x * x) / 12}" />
+    </xacro:macro>
 
-<xacro:macro name="sphere_inertia" params="m r">
-	<inertia ixx="${2 * m * r * r / 5}" ixy="0" ixz="0"
-		iyy="${2 * m * r * r / 5}" iyz="0"
-		izz="${2 * m * r * r / 5}"
-	/>
-</xacro:macro>
+    <xacro:macro name="sphere_inertia" params="m r">
+        <inertia ixx="${2 * m * r * r / 5}" ixy="0" ixz="0" iyy="${2 * m * r * r / 5}" iyz="0" izz="${2 * m * r * r / 5}" />
+    </xacro:macro>
 
-<!-- ............................... TROLLEY WHEEL DEFINITION .............................. -->
+    <!-- ............................... TROLLEY WHEEL DEFINITION .............................. -->
 
-<xacro:macro name="trolley_wheel" params="cardinality dexterity origin_x origin_y origin_z">
-	<link name="${cardinality}_${dexterity}_wheel">
-		<collision>
-			<origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
-			<geometry>
-				<sphere radius="${trolley_wheel_radius}"/>
-			</geometry>
-		</collision>
+    <xacro:macro name="trolley_wheel" params="cardinality dexterity origin_x origin_y origin_z">
+        <link name="${cardinality}_${dexterity}_wheel">
+            <collision>
+                <origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
+                <geometry>
+                    <sphere radius="${trolley_wheel_radius}"/>
+                </geometry>
+            </collision>
 
-		<inertial>
-			<origin xyz="0 0 0" rpy="0 0 0" />
-			<mass value="${trolley_wheel_mass}"/>
-			<xacro:sphere_inertia m="${trolley_wheel_mass}" r="${trolley_wheel_radius}"/>
-		</inertial>
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <mass value="${trolley_wheel_mass}"/>
+                <xacro:sphere_inertia m="${trolley_wheel_mass}" r="${trolley_wheel_radius}"/>
+            </inertial>
 
-		<mu>0.0</mu>
-	</link>
+            <mu>0.0</mu>
+        </link>
 
-	<joint name="${cardinality}_${dexterity}_wheel_joint" type="fixed">
-		<parent link="base_link"/>
-		<child link="${cardinality}_${dexterity}_wheel"/>
-		<origin xyz="${origin_x} ${origin_y} ${origin_z}" rpy="0 0 0" />
-		<axis xyz="0 1 0" rpy="0 0 0" />
-	</joint>
+        <joint name="${cardinality}_${dexterity}_wheel_joint" type="fixed">
+            <parent link="base_link"/>
+            <child link="${cardinality}_${dexterity}_wheel"/>
+            <origin xyz="${origin_x} ${origin_y} ${origin_z}" rpy="0 0 0" />
+            <axis xyz="0 1 0" rpy="0 0 0" />
+        </joint>
 
-	<gazebo reference="${cardinality}_${dexterity}_wheel">
-		<material>Gazebo/Black</material>
-	</gazebo>
-</xacro:macro>
+        <gazebo reference="${cardinality}_${dexterity}_wheel">
+            <material>Gazebo/Black</material>
+        </gazebo>
+    </xacro:macro>
 
+    <xacro:macro name="traction_wheel" params="cardinality dexterity origin_x origin_y origin_z">
+        <link name="${cardinality}_${dexterity}_wheel">
+            <collision>
+                <origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
+                <geometry>
+                    <cylinder length="${traction_wheel_width}" radius="${traction_wheel_radius}"/>
+                </geometry>
+            </collision>
 
-<xacro:macro name="traction_wheel" params="cardinality dexterity origin_x origin_y origin_z">
-	<link name="${cardinality}_${dexterity}_wheel">
-		<collision>
-			<origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
-			<geometry>
-				<cylinder length="${traction_wheel_width}" radius="${traction_wheel_radius}"/>
-			</geometry>
-		</collision>
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
+                <mass value="${traction_wheel_mass}"/>
+                <xacro:cylinder_inertia m="${traction_wheel_mass}" r="${traction_wheel_radius}" h="${traction_wheel_width}"/>
+            </inertial>
 
-		<inertial>
-			<origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
-			<mass value="${traction_wheel_mass}"/>
-			<xacro:cylinder_inertia m="${traction_wheel_mass}" r="${traction_wheel_radius}" h="${traction_wheel_width}"/>
-		</inertial>
+            <mu>5.0</mu>
+        </link>
 
-		<mu>5.0</mu>
-	</link>
+        <joint name="${cardinality}_${dexterity}_wheel_joint" type="continuous">
+            <parent link="base_link"/>
+            <child link="${cardinality}_${dexterity}_wheel"/>
+            <origin xyz="${origin_x} ${origin_y} ${origin_z}" rpy="0 0 0" />
+            <axis xyz="0 1 0" rpy="0 0 0" />
+        </joint>
 
-	<joint name="${cardinality}_${dexterity}_wheel_joint" type="continuous">
-		<parent link="base_link"/>
-		<child link="${cardinality}_${dexterity}_wheel"/>
-		<origin xyz="${origin_x} ${origin_y} ${origin_z}" rpy="0 0 0" />
-		<axis xyz="0 1 0" rpy="0 0 0" />
-	</joint>
-
-	<gazebo reference="${cardinality}_${dexterity}_wheel">
-		<material>Gazebo/Black</material>
-	</gazebo>
-</xacro:macro>
+        <gazebo reference="${cardinality}_${dexterity}_wheel">
+            <material>Gazebo/Black</material>
+        </gazebo>
+    </xacro:macro>
 
 </robot>

--- a/urdf/materials.xacro
+++ b/urdf/materials.xacro
@@ -1,56 +1,56 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_bot">
 
-	<material name="black">
-		<color rgba="0.0 0.0 0.0 1.0"/>
-	</material>
+    <material name="black">
+        <color rgba="0.0 0.0 0.0 1.0"/>
+    </material>
 
-	<material name="blue">
-		<color rgba="0.0 0.0 0.8 1.0"/>
-	</material>
+    <material name="blue">
+        <color rgba="0.0 0.0 0.8 1.0"/>
+    </material>
 
-	<material name="green">
-		<color rgba="0.0 0.8 0.0 1.0"/>
-	</material>
+    <material name="green">
+        <color rgba="0.0 0.8 0.0 1.0"/>
+    </material>
 
-	<material name="yellow">
-		<color rgba="1.0 1.0 0.0 1.0"/>
-	</material>
+    <material name="yellow">
+        <color rgba="1.0 1.0 0.0 1.0"/>
+    </material>
 
-	<material name="dark_grey">
-		<color rgba="0.2 0.2 0.2 1.0"/>
-	</material>
+    <material name="dark_grey">
+        <color rgba="0.2 0.2 0.2 1.0"/>
+    </material>
 
-	<material name="orange">
-		<color rgba="${255/255} ${108/255} ${10/255} 1.0"/>
-	</material>
+    <material name="orange">
+        <color rgba="${255/255} ${108/255} ${10/255} 1.0"/>
+    </material>
 
-	<material name="brown">
-		<color rgba="${139/255} ${69/255} ${19/255} 1.0"/>
-	</material>
+    <material name="brown">
+        <color rgba="${139/255} ${69/255} ${19/255} 1.0"/>
+    </material>
 
-	<material name="red">
-		<color rgba="0.8 0.0 0.0 1.0"/>
-	</material>
+    <material name="red">
+        <color rgba="0.8 0.0 0.0 1.0"/>
+    </material>
 
-	<material name="turquoise">
-		<color rgba="${64/255} ${224/255} ${208/255} 1.0"/>
-	</material>
+    <material name="turquoise">
+        <color rgba="${64/255} ${224/255} ${208/255} 1.0"/>
+    </material>
 
-	<material name="purple">
-		<color rgba="${128/255} ${0/255} ${128/255} 1.0"/>
-	</material>
+    <material name="purple">
+        <color rgba="${128/255} ${0/255} ${128/255} 1.0"/>
+    </material>
 
-	<material name="white">
-		<color rgba="1.0 1.0 1.0 1.0"/>
-	</material>
+    <material name="white">
+        <color rgba="1.0 1.0 1.0 1.0"/>
+    </material>
 
-	<material name="aluminium">
-		<color rgba="0.5 0.5 0.5 1"/>
-	</material>
+    <material name="aluminium">
+        <color rgba="0.5 0.5 0.5 1"/>
+    </material>
 
-	<material name="plastic">
-		<color rgba="0.1 0.1 0.1 1"/>
-	</material>
+    <material name="plastic">
+        <color rgba="0.1 0.1 0.1 1"/>
+    </material>
 
 </robot>


### PR DESCRIPTION
**Description:**
This pull request adds support for a stereo camera to the `bcr_bot` for ignition and gazebo classic 
**Files Changed:**

1. **README.md:**
   - Updated the README.md file to include information about the newly added stereo camera and its usage.

2. **launch/gazebo.launch.py:**
   - Modified the `gazebo.launch` file to include the stereo camera in the robot's launch configuration.
   - 
3. **launch/gz.launch.py:**
   - Modified the `gz.launch.py` file to include the stereo camera in the robot's launch configuration.
   
4. **urdf/bcr_bot.xacro:**
   - Added a new link and joint for the stereo camera to the `bcr_bot` URDF model.
   
5. **urdf/gazebo.xacro:**
   - Added the stereo camera plugin to the `gazebo.xacro` file to enable simulation of the stereo camera.
  
6. **urdf/gz.xacro:**
   - Added the stereo camera plugin to the `gz.xacro` file to enable simulation of the stereo camera in ignition.

**Testing:**
- Tested the changes in a Gazebo simulation and ignition simulation environment with stereo_image_proc 
