### PR TITLE
Add empty world in ROS1

### DIFF
--- a/worlds/empty.world
+++ b/worlds/empty.world
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sdf version="1.5">
+    <world name="empty_world">
+        <light type="directional" name="sun">
+            <cast_shadows>true</cast_shadows>
+            <pose>0 0 10 0 0 0</pose>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+            <attenuation>
+                <range>1000</range>
+                <constant>0.9</constant>
+                <linear>0.01</linear>
+                <quadratic>0.001</quadratic>
+            </attenuation>
+            <direction>-0.5 0.1 -0.9</direction>
+        </light>
+        
+        <model name="ground_plane">
+            <static>true</static>
+           <link name="link">
+                <collision name="collision">
+                    <geometry>
+                        <plane>
+                            <normal>0 0 1</normal>
+                        </plane>
+                    </geometry>
+                </collision>
+                <visual name="visual">
+                    <geometry>
+                        <plane>
+                            <normal>0 0 1</normal>
+                            <size>100 100</size>
+                        </plane>
+                    </geometry>
+                    <material>
+                        <ambient>0.8 0.8 0.8 1</ambient>
+                        <diffuse>0.8 0.8 0.8 1</diffuse>
+                        <specular>0.8 0.8 0.8 1</specular>
+                    </material>
+                </visual>
+            </link>
+        </model>
+    </world>
+</sdf> 


### PR DESCRIPTION
### Description 
Added an empty world

### Checklist 
- Tested the ROS1 package by building in docker container 
- Launched the bcr_bot in the empty world inside same docker container successfully
- No default parameters are changed the bcr_bot can be spawned in empty world by ```roslaunch bcr_bot gazebo.launch world_name:=empty.world ```

Result:
![image](https://github.com/blackcoffeerobotics/bcr_bot/assets/87593991/074a02b1-3059-4b40-bf29-57a79e73e414)
