### PR TITLE
Ensuring sims start on launch

### DIFF
--- a/launch/gz.launch.py
+++ b/launch/gz.launch.py
@@ -5,7 +5,7 @@ from xacro import parse, process_doc
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.substitutions import LaunchConfiguration, Command
+from launch.substitutions import LaunchConfiguration, Command, PythonExpression
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 from launch_ros.actions import Node
@@ -60,7 +60,7 @@ def generate_launch_description():
     gz_sim = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(join(gz_sim_share, "launch", "gz_sim.launch.py")),
         launch_arguments={
-            "gz_args" : world_file
+            "gz_args" : PythonExpression(["'", world_file, " -r'"])
         }.items()
     )
 

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,8 @@
 	<exec_depend>launch_ros</exec_depend>
 	<exec_depend>robot_state_publisher</exec_depend>
 	<exec_depend>xacro</exec_depend>
+	<exec_depend>ros_gz</exec_depend>
+	<exec_depend>gazebo_ros</exec_depend>
 
 	<test_depend>ament_cmake_gtest</test_depend>
 	<test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
### Main Checks
* humble + fortress sim starts on launch after commit. (changed)
* humble + classic starts on launch (unchanged)

### additional 
* updated package.xml to include `ros_gz` and `gazebo_ros` as `exec_depend`. 