### PR TITLE
Add a Ground truth source for the odometry in Fortress. Fixes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ ros2 launch bcr_bot gz.launch.py \
 	position_x:=0.0 \
 	position_y:=0.0  \
 	orientation_yaw:=0.0 \
+	odometry_source:=world \
 	world_file:=small_warehouse.sdf
 ```
 **Note:** To use stereo_image_proc with the stereo images excute following command: 

--- a/launch/gz.launch.py
+++ b/launch/gz.launch.py
@@ -29,6 +29,7 @@ def generate_launch_description():
     camera_enabled = LaunchConfiguration("camera_enabled", default=True)
     stereo_camera_enabled = LaunchConfiguration("stereo_camera_enabled", default=False)
     two_d_lidar_enabled = LaunchConfiguration("two_d_lidar_enabled", default=True)
+    odometry_source = LaunchConfiguration("odometry_source")
 
     # robot_description_content = get_xacro_to_doc(
     #     join(bcr_bot_path, "urdf", "bcr_bot.xacro"),
@@ -49,6 +50,7 @@ def generate_launch_description():
                     ' camera_enabled:=', camera_enabled,
                     ' stereo_camera_enabled:=', stereo_camera_enabled,
                     ' two_d_lidar_enabled:=', two_d_lidar_enabled,
+                    ' odometry_source:=', odometry_source,
                     ' sim_gz:=', "true"
                     ])}],
         remappings=[
@@ -135,7 +137,8 @@ def generate_launch_description():
         DeclareLaunchArgument("two_d_lidar_enabled", default_value = two_d_lidar_enabled),
         DeclareLaunchArgument("position_x", default_value="0.0"),
         DeclareLaunchArgument("position_y", default_value="0.0"),
-        DeclareLaunchArgument("orientation_yaw", default_value="0.0"),        
+        DeclareLaunchArgument("orientation_yaw", default_value="0.0"),
+        DeclareLaunchArgument("odometry_source", default_value="world"),
         robot_state_publisher,
         gz_sim, gz_spawn_entity, gz_ros2_bridge,
         transform_publisher

--- a/urdf/gz.xacro
+++ b/urdf/gz.xacro
@@ -23,12 +23,30 @@
             <wheel_radius>${traction_wheel_radius+0.01}</wheel_radius>
             <odom_publish_frequency>30</odom_publish_frequency>
             <topic>/cmd_vel</topic>
-            <odom_topic>$(arg wheel_odom_topic)</odom_topic>
-            <tf_topic>/tf</tf_topic>
+            <xacro:if value="${odometry_source == 'encoders'}">
+                <odom_topic>$(arg wheel_odom_topic)</odom_topic>
+                <tf_topic>/tf</tf_topic>
+            </xacro:if>
             <frame_id>odom</frame_id>
             <child_frame_id>base_link</child_frame_id>
         </plugin>
     </gazebo>
+
+    <!-- ............................. ground truth .................................... -->
+
+    <xacro:if value="${odometry_source == 'world'}">
+    <gazebo>
+        <plugin filename="libignition-gazebo6-odometry-publisher-system"
+            name="ignition::gazebo::systems::OdometryPublisher">
+            <odom_frame>odom</odom_frame>
+            <robot_base_frame>base_link</robot_base_frame>
+            <odom_topic>$(arg wheel_odom_topic)</odom_topic>
+            <tf_topic>/tf</tf_topic>
+            <dimensions>2</dimensions>
+            <odom_publish_frequency>10</odom_publish_frequency>
+        </plugin>
+    </gazebo>
+    </xacro:if>
 
     <!-- ........................... 2D LIDAR config ................................... -->
 


### PR DESCRIPTION
## Description

Similar to Humble + classic, the humble + fortress sim can now be launched with an option for odometry source. `gz.launch.py odometry_source:=world` or `gz.launch.py odometry_source:=encoders`. Where world corresponds to ground truth. Fixes #16 

## Changes made to enable ground truth
* added OdometryPublisher system to the xacro.
* added CLI option for gz.launch.py to switch between "encoders" and "world"