### PR TITLE
Ros2 collision fix

### DIFF
--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -103,8 +103,8 @@
     <xacro:trolley_wheel cardinality="back" dexterity="left" origin_x="-${chassis_length/2}" origin_y="${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
     <xacro:trolley_wheel cardinality="back" dexterity="right" origin_x="-${chassis_length/2}" origin_y="-${trolley_track_width/2}" origin_z="-${trolley_wheel_radius+chassis_height/2}"/>
 
-    <xacro:traction_wheel cardinality="middle" dexterity="left" origin_x="0" origin_y="${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
-    <xacro:traction_wheel cardinality="middle" dexterity="right" origin_x="0" origin_y="-${traction_track_width/2}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
+    <xacro:traction_wheel cardinality="middle" dexterity="left" origin_x="0" origin_y="${traction_track_width/2.75}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
+    <xacro:traction_wheel cardinality="middle" dexterity="right" origin_x="0" origin_y="-${traction_track_width/2.75}" origin_z="-${chassis_height/2+2*trolley_wheel_radius+eps-traction_wheel_radius}"/>
 
     <!-- ............................. 2D LIDAR ........................................ -->
 

--- a/urdf/macros.xacro
+++ b/urdf/macros.xacro
@@ -49,12 +49,15 @@
 
     <xacro:macro name="traction_wheel" params="cardinality dexterity origin_x origin_y origin_z">
         <link name="${cardinality}_${dexterity}_wheel">
+
             <collision>
                 <origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />
                 <geometry>
                     <cylinder length="${traction_wheel_width}" radius="${traction_wheel_radius}"/>
                 </geometry>
+                <self_collide>false</self_collide>
             </collision>
+
 
             <inertial>
                 <origin xyz="0 0 0" rpy="0 ${pi/2} ${pi/2}" />


### PR DESCRIPTION
Description:

This pull request addresses issue https://github.com/blackcoffeerobotics/bcr_bot/issues/23. The issue was regarding misalignment of the wheels causing them to be out of the chassis in the simulation test. The changes made in this PR have corrected the alignment of the wheels, allowing them to move correctly within the chassis during simulation tests.

Changes Made:

Fixed misalignment of wheels.
Ensured wheels are movable within the chassis in simulation tests.



Checklist
Create tests, which fail without this PR.

[Screencast from 03-13-2024 04_34_11 PM.webm](https://github.com/blackcoffeerobotics/bcr_bot/assets/94218410/0fde341f-1789-43d7-9b8f-2c2ce4c164e5)
[Screencast from 03-13-2024 04_27_30 PM.webm](https://github.com/blackcoffeerobotics/bcr_bot/assets/94218410/7d704f74-e359-4fb8-acd9-2dee3fe9bb7f)

 
 
