### PR TITLE
Refactored Gazebo launch to dynamically spawn bcr_bot

### DIFF
--- a/launch/bcr_bot_spawn.launch
+++ b/launch/bcr_bot_spawn.launch
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<launch>
+
+<!--............................ CONFIGURABLE PARAMETERS .............................-->
+
+
+<arg name="two_d_lidar_enabled"		default="true"/>
+<arg name="camera_enabled"			default="true"/>
+<arg name="stereo_camera_enabled"	default="false"/>
+<arg name="wheel_odom_topic"		default="odom"/>
+<arg name="publish_wheel_odom_tf"	default="true"/>
+<arg name="conveyor_enabled"        default="false"/>
+<arg name="ground_truth_frame"      default="map"/>
+<arg name="robot_namespace"         default=""/>
+<arg name="position_x"              default="0.0"/>
+<arg name="position_y"              default="0.0"/>
+<arg name="orientation_yaw"         default="0.0"/>
+<arg name="odometry_source"         default="world"/>
+
+<!-- ................................ XACRO CALL .................................... -->
+
+<param name="robot_description" command="$(find xacro)/xacro $(find bcr_bot)/urdf/bcr_bot.xacro
+	two_d_lidar_enabled:=$(arg two_d_lidar_enabled)
+	camera_enabled:=$(arg camera_enabled)
+	stereo_camera_enabled:=$(arg stereo_camera_enabled)
+	wheel_odom_topic:=$(arg wheel_odom_topic)
+	publish_wheel_odom_tf:=$(arg publish_wheel_odom_tf)
+	conveyor_enabled:=$(arg conveyor_enabled)
+	ground_truth_frame:=$(arg ground_truth_frame)
+	robot_namespace:=$(arg robot_namespace)
+	odometry_source:=$(arg odometry_source)
+	" />
+
+<!-- ................................ SPAWN MODEL .................................... -->
+
+
+<node name="spawn_model" pkg="gazebo_ros" type="spawn_model"
+	args="-param robot_description
+		-urdf
+		-model $(arg robot_namespace)_robot
+		-x $(arg position_x)
+        -y $(arg position_y)
+		-z 0.9
+		-Y $(arg orientation_yaw)"
+
+	output="screen" />
+
+<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher">
+	<remap from="/joint_states" to="$(arg robot_namespace)/joint_states"/>
+</node>
+
+</launch>

--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -5,21 +5,8 @@
 <!--............................ CONFIGURABLE PARAMETERS .............................-->
 
 <env name="GAZEBO_MODEL_PATH" value="$(find bcr_bot)/models:$(optenv GAZEBO_MODEL_PATH)"/>
-
-<arg name="gazebo_gui_enabled" 		default="true"/>
-<arg name="two_d_lidar_enabled"		default="true"/>
-<arg name="camera_enabled"			default="true"/>
-<arg name="stereo_camera_enabled"	default="false"/>
-<arg name="wheel_odom_topic"		default="odom"/>
-<arg name="publish_wheel_odom_tf"	default="true"/>
-<arg name="conveyor_enabled"        default="false"/>
-<arg name="ground_truth_frame"      default="map"/>
-<arg name="robot_namespace"         default=""/>
 <arg name="world_name"              default="$(find bcr_bot)/worlds/small_warehouse.world"/>
-<arg name="position_x"              default="0.0"/>
-<arg name="position_y"              default="0.0"/>
-<arg name="orientation_yaw"         default="0.0"/>
-<arg name="odometry_source"         default="world"/>
+<arg name="gazebo_gui_enabled" 		default="true"/>
 
 <!-- ............................... LAUNCH WORLD ................................... -->
 
@@ -32,36 +19,10 @@
 	<arg name="debug"         value="false"/>
 </include>
 
-<!-- ................................ XACRO CALL .................................... -->
 
-<param name="robot_description" command="$(find xacro)/xacro $(find bcr_bot)/urdf/bcr_bot.xacro
-	two_d_lidar_enabled:=$(arg two_d_lidar_enabled)
-	camera_enabled:=$(arg camera_enabled)
-	stereo_camera_enabled:=$(arg stereo_camera_enabled)
-	wheel_odom_topic:=$(arg wheel_odom_topic)
-	publish_wheel_odom_tf:=$(arg publish_wheel_odom_tf)
-	conveyor_enabled:=$(arg conveyor_enabled)
-	ground_truth_frame:=$(arg ground_truth_frame)
-	robot_namespace:=$(arg robot_namespace)
-	odometry_source:=$(arg odometry_source)
-	" />
+<!-- .....................Call the launch file to spawn the robot ................... -->
 
-<!-- ................................ SPAWN MODEL .................................... -->
+<include file="$(find bcr_bot)/launch/bcr_bot_spawn.launch"/>
 
-
-<node name="spawn_model" pkg="gazebo_ros" type="spawn_model"
-	args="-param robot_description
-		-urdf
-		-model $(arg robot_namespace)_robot
-		-x $(arg position_x)
-        -y $(arg position_y)
-		-z 0.9
-		-Y $(arg orientation_yaw)"
-
-	output="screen" />
-
-<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher">
-	<remap from="/joint_states" to="$(arg robot_namespace)/joint_states"/>
-</node>
 
 </launch>


### PR DESCRIPTION
# Merge Request: Implement Dynamic Spawning for bcr_bot in Gazebo (ROS 1)

## Description
This merge request implements a dynamic spawning mechanism for the `bcr_bot` robot in Gazebo. It involves the creation of two new files: `bcr_bot_spawn.launch` , which is used to spawn robots into any world without being tied to specific configurations. Additionally, modifications is made to `gazebo.launch` to call these spawn files, removing hardcoded bot spawning.

## Changes Made
1. Created `bcr_bot_spawn.launch`: This file is responsible for spawning robots into Gazebo worlds.
2. Modified `gazebo.launch`: Updated to call `bcr_bot_spawn.launch` for dynamic bot spawning.

## Test Cases
1. Ran usual Gazebo with parameters: **Tested and Passed**
3. Ran robot in Gazebo: **Tested and Passed**
5. Spawned robot in another Gazebo world with parameters: **Tested and Passed**
6. Ran robot in another Gazebo world : **Tested and Passed**

## Additional Information
- Squashed commits: **Done**

## Video of Testing 
1. test case 1: [Screencast from 03-28-2024 04:49:16 PM.webm](https://github.com/blackcoffeerobotics/bcr_bot/assets/94218410/f6339d2d-7e10-42b2-bd8f-7097a62aec7f) 
2. test case 2: [Screencast from 03-28-2024 04:51:34 PM.webm](https://github.com/blackcoffeerobotics/bcr_bot/assets/94218410/97cddcb4-dfa7-4044-8923-58e1adab41d4)
3. test case 3:[Screencast from 03-28-2024 04:55:30 PM.webm](https://github.com/blackcoffeerobotics/bcr_bot/assets/94218410/b3dcb286-7651-42c7-8dca-95720a4ff38e)
4. test case 4: [Screencast from 03-28-2024 04:55:51 PM.webm](https://github.com/blackcoffeerobotics/bcr_bot/assets/94218410/a4532eb8-97e8-4b21-87b7-0f758cefb59c)
