### PR TITLE
Added base_footprint tf

### DIFF
--- a/launch/bcr_bot_gz_spawn.launch.py
+++ b/launch/bcr_bot_gz_spawn.launch.py
@@ -113,7 +113,7 @@ def generate_launch_description():
                     "--pitch", "0.0",
                     "--roll", "0.0",
                     "--frame-id", "kinect_camera",
-                    "--child-frame-id", "bcr_bot/base_link/kinect_camera"]
+                    "--child-frame-id", "bcr_bot/base_footprint/kinect_camera"]
     )
 
     return LaunchDescription([

--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -63,8 +63,15 @@
     </xacro:if>
 
     <!-- ................................ BASE LINK .................................. -->
+    <link name="base_footprint"/>
 
     <link name="base_link"/>
+
+    <joint name="base_joint" type="fixed">
+        <parent link="base_footprint"/>
+        <child link="base_link"/>
+        <origin xyz="0.0 0 ${chassis_height/2 + traction_wheel_radius}" rpy="0 0 0.0" />
+    </joint>
 
     <link name="chassis_link">
 

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -20,7 +20,7 @@
             <right_joint>middle_right_wheel_joint</right_joint>
             <wheel_separation>${traction_track_width+traction_wheel_width-0.01}</wheel_separation>
             <wheel_diameter>${2*traction_wheel_radius+0.01}</wheel_diameter>
-            <robot_base_frame>base_link</robot_base_frame>
+            <robot_base_frame>base_footprint</robot_base_frame>
             <max_wheel_torque>${traction_max_wheel_torque}</max_wheel_torque>
             <command_topic>cmd_vel</command_topic>
             <odometry_topic>$(arg wheel_odom_topic)</odometry_topic>
@@ -66,7 +66,7 @@
             </ros>
             <always_on>true</always_on>
             <update_rate>30.0</update_rate>
-            <body_name>base_link</body_name>
+            <body_name>base_footprint</body_name>
             <gaussian_noise>0.00</gaussian_noise>
             <frame_name>$(arg ground_truth_frame)</frame_name>
         </plugin>

--- a/urdf/gz.xacro
+++ b/urdf/gz.xacro
@@ -28,7 +28,7 @@
                 <tf_topic>/tf</tf_topic>
             </xacro:if>
             <frame_id>odom</frame_id>
-            <child_frame_id>base_link</child_frame_id>
+            <child_frame_id>base_footprint</child_frame_id>
         </plugin>
     </gazebo>
 
@@ -39,7 +39,7 @@
         <plugin filename="libignition-gazebo6-odometry-publisher-system"
             name="ignition::gazebo::systems::OdometryPublisher">
             <odom_frame>odom</odom_frame>
-            <robot_base_frame>base_link</robot_base_frame>
+            <robot_base_frame>base_footprint</robot_base_frame>
             <odom_topic>$(arg wheel_odom_topic)</odom_topic>
             <tf_topic>/tf</tf_topic>
             <dimensions>2</dimensions>


### PR DESCRIPTION
# Basic Info
| Info  | Details |
| ------------- | ------------- |
| Ticket(s) this addresses | #33  |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Ignition Gazebo |

# Changes
- Added tf frame base_footprint and fixed joint base_joint from base_footprint to base_link in `bcr_bot.xacro`
- Changed static transform publisher to publish `bcr_bot/base_footprint/kinect_camera` in fortress spawn launch file
- Refactored `base_link` to `base_footprint` in `gazebo.xacro` and `gz.xacro`

# Tests Run
- Verified TF trees for gazebo classic and igniton fortress
- Proper functioning and visualization of all sensors with rviz2
- Out of the box compatibility with nav2 for classic

## Nav2 Map fix
* Before:
   ![bcr_bot_map_thru_bot](https://github.com/blackcoffeerobotics/bcr_bot/assets/123073764/0983481f-55ed-4adc-8617-52d8bed4ba58)
* After
   ![bcr_bot_map_below_bot](https://github.com/blackcoffeerobotics/bcr_bot/assets/123073764/32cde23e-43f8-46dc-87d2-41210f6b145c)