### PR TITLE
Ros1 base footprint tf fix

### DIFF
--- a/urdf/bcr_bot.xacro
+++ b/urdf/bcr_bot.xacro
@@ -53,8 +53,15 @@
     <xacro:include filename="$(find bcr_bot)/urdf/gazebo.xacro"/>
 
     <!-- ................................ BASE LINK .................................. -->
+    <link name="base_footprint"/>
 
     <link name="base_link"/>
+
+    <joint name="base_joint" type="fixed">
+        <parent link="base_footprint"/>
+        <child link="base_link"/>
+        <origin xyz="0.0 0 ${chassis_height/2 + traction_wheel_radius}" rpy="0 0 0.0" />
+    </joint>
 
     <link name="chassis_link">
 

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -16,7 +16,7 @@
             <rightJoint>middle_right_wheel_joint</rightJoint>
             <wheelSeparation>${traction_track_width+traction_wheel_width-0.01}</wheelSeparation>
             <wheelDiameter>${2*traction_wheel_radius+0.01}</wheelDiameter>
-            <robotBaseFrame>base_link</robotBaseFrame>
+            <robotBaseFrame>base_footprint</robotBaseFrame>
             <wheelTorque>${traction_max_wheel_torque}</wheelTorque>
             <commandTopic>cmd_vel</commandTopic>
             <odometryTopic>$(arg wheel_odom_topic)</odometryTopic>
@@ -51,7 +51,7 @@
             <robotNamespace>$(arg robot_namespace)</robotNamespace>
             <alwaysOn>true</alwaysOn>
             <updateRate>30.0</updateRate>
-            <bodyName>base_link</bodyName>
+            <bodyName>base_footprint</bodyName>
             <topicName>ground_truth_pose</topicName>
             <gaussianNoise>0.00</gaussianNoise>
             <frameName>$(arg ground_truth_frame)</frameName>


### PR DESCRIPTION
# Basic Info
| Info  | Details |
| ------------- | ------------- |
| Ticket(s) this addresses | #33  |
| Primary OS tested on | Ubuntu 20.04 in Docker |

# Changes
- Added tf frame base_footprint and fixed joint base_joint from base_footprint to base_link in `bcr_bot.xacro`
- Refactored `base_link` to `base_footprint` in `gazebo.xacro`.

# Tests Run
- Verified TF trees for gazebo classic
- Proper functioning and visualization of all sensors with rviz2
- Slam using gmapping. [Output](https://drive.google.com/file/d/1AfYpDAvia4Rhr02t5OB6dm7r8CwG4sH1/view?usp=sharing)