### PR TITLE
[wip] Adding support and testing functionality with ros2 jazzy

### DIFF
--- a/bash_into_container.sh
+++ b/bash_into_container.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+xhost +local:root
+
+docker exec -it --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" -e "ROS_DOMAIN_ID=0" bcr_arm_container /bin/bash -c "cd /bcr_ws && colcon build && source install/setup.bash && exec bash"
+
+xhost -local:root

--- a/start_container.sh
+++ b/start_container.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Start a new BCR ARM container if not already running
+if [ ! "$(docker ps -q -f name=bcr_arm_container)" ]; then
+    if [ "$(docker ps -aq -f status=exited -f name=bcr_arm_container)" ]; then
+        # Container exists but is stopped, remove it
+        docker rm bcr_arm_container
+    fi
+    
+    # Enable X11 forwarding
+    xhost +local:docker
+    
+    # Start new container
+    docker run -it \
+        --name bcr_arm_container \
+        --network host \
+        -e DISPLAY=$DISPLAY \
+        -e QT_X11_NO_MITSHM=1 \
+        -e CYCLONEDX_URI=/ddsconfig.xml \
+        -e ROS_DOMAIN_ID=0 \
+        -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+        -v /dev/dri:/dev/dri \
+        -v "$(dirname "$0")/../../docker/ddsconfig.xml":/ddsconfig.xml \
+        -v "$(dirname "$0")":/bcr_ws/src/bcr_bot \
+        --privileged \
+        bcr_arm:jazzy-harmonic \
+        /bin/bash -c "cd /bcr_ws && rosdep install -i --from-path src --rosdistro jazzy -y && . /opt/ros/jazzy/setup.bash && colcon build && exec bash"
+        
+    echo "BCR ARM container started."
+else
+    echo "BCR ARM container is already running."
+fi


### PR DESCRIPTION
Tha goal is to ensure BCR Bot is functioning correctly on ROS2 jazzy with GZ harmonic.

Based on my initial testing, everything seems to work out of the box with the instructions for ROS2 Humble and GZ Harmonic, even using docker container to run the scripts.

![Screenshot of working functionality on jazzy](https://github.com/user-attachments/assets/332284a1-d025-46ad-8e65-cdc09812c189)


Changes: added script for starting docker container (will remove later) - this is wip